### PR TITLE
Spring Security 인증/인가 구조 개편 및 GUEST 로그인 도입 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ gradle/
 /src/main/resources/*.yml
 !/src/main/resources/application.yml
 src/main/java/page/clab/api/global/auth/application/DataLoader.java
-src/main/java/page/clab/api/global/auth/service/DataLoader.java
+src/main/java/page/clab/api/global/auth/application/MemberFactory.java
 src/main/java/page/clab/api/global/config/SecurityProperties.java
 /config/whitelist.json
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -43,7 +43,7 @@ public class ActivityGroupAdminController {
     private final PageableUtils pageableUtils;
 
     @Operation(summary = "[U] 활동 생성", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> createActivityGroup(
             @Valid @RequestBody ActivityGroupRequestDto requestDto
@@ -53,7 +53,7 @@ public class ActivityGroupAdminController {
     }
 
     @Operation(summary = "[U] 활동 수정", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{activityGroupId}")
     public ApiResponse<Long> updateActivityGroup(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
@@ -64,7 +64,7 @@ public class ActivityGroupAdminController {
     }
 
     @Operation(summary = "[A] 활동 상태 변경", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("manage/{activityGroupId}")
     public ApiResponse<Long> manageActivityGroupStatus(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
@@ -75,7 +75,7 @@ public class ActivityGroupAdminController {
     }
 
     @Operation(summary = "[A] 활동 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{activityGroupId}")
     public ApiResponse<Long> deleteActivityGroup(
             @PathVariable(name = "activityGroupId") Long activityGroupId
@@ -86,7 +86,7 @@ public class ActivityGroupAdminController {
 
     @Operation(summary = "[U] 프로젝트 진행도 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "진행도는 0~100 사이의 값으로 입력해야 함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/progress/{activityGroupId}")
     public ApiResponse<Long> updateProjectProgress(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
@@ -97,7 +97,7 @@ public class ActivityGroupAdminController {
     }
 
     @Operation(summary = "[U] 커리큘럼 및 일정 생성", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/schedule")
     public ApiResponse<Long> addSchedule(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -110,7 +110,7 @@ public class ActivityGroupAdminController {
     @Operation(summary = "[U] 활동 멤버 및 지원서 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "관리자 또는 리더만 조회 가능<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/members")
     public ApiResponse<PagedResponseDto<ActivityGroupMemberWithApplyReasonResponseDto>> getApplyGroupMemberList(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -125,7 +125,7 @@ public class ActivityGroupAdminController {
     }
 
     @Operation(summary = "[U] 신청 멤버 상태 변경", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/accept")
     public ApiResponse<String> acceptGroupMember(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -138,7 +138,7 @@ public class ActivityGroupAdminController {
 
     @GetMapping("/deleted")
     @Operation(summary = "[S] 삭제된 활동그룹 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getDeletedActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -48,7 +48,7 @@ public class ActivityGroupBoardController {
             "제출 : 부모 게시판(과제), 첨부파일 경로 리스트<br>" +
             "피드백 : 부모 게시판(제출), 카테고리, 내용 , 첨부파일 경로 리스트(선택)"
     )
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> createActivityGroupBoard(
             @RequestParam(name = "parentId", required = false) Long parentId,
@@ -61,7 +61,7 @@ public class ActivityGroupBoardController {
 
     @Operation(summary = "[U] 활동 그룹 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/list")
     public ApiResponse<PagedResponseDto<ActivityGroupBoardResponseDto>> getActivityGroupBoardList(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -75,7 +75,7 @@ public class ActivityGroupBoardController {
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 단일 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<ActivityGroupBoardResponseDto> getActivityGroupBoardById(
             @RequestParam(name = "activityGroupBoardId") Long activityGroupBoardId
@@ -86,7 +86,7 @@ public class ActivityGroupBoardController {
 
     @Operation(summary = "[U] 활동 그룹 ID에 대한 카테고리별 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/by-category")
     public ApiResponse<PagedResponseDto<ActivityGroupBoardResponseDto>> getActivityGroupBoardByCategory(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -102,7 +102,7 @@ public class ActivityGroupBoardController {
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 계층 구조적 조회, 부모 및 자식 게시판 함께 반환", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/by-parent")
     public ApiResponse<PagedResponseDto<ActivityGroupBoardChildResponseDto>> getActivityGroupBoardByParent(
             @RequestParam(name = "parentId") Long parentId,
@@ -115,7 +115,7 @@ public class ActivityGroupBoardController {
     }
 
     @Operation(summary = "[U] 나의 제출 과제 및 피드백 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-assignment")
     public ApiResponse<List<AssignmentSubmissionWithFeedbackResponseDto>> getMyAssignmentBoardWithFeedback(
             @RequestParam(name = "parentId") Long parentId
@@ -125,7 +125,7 @@ public class ActivityGroupBoardController {
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 수정", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("")
     public ApiResponse<ActivityGroupBoardUpdateResponseDto> updateActivityGroupBoard(
             @RequestParam(name = "activityGroupBoardId") Long activityGroupBoardId,
@@ -136,7 +136,7 @@ public class ActivityGroupBoardController {
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("")
     public ApiResponse<Long> deleteActivityGroupBoard(
             @RequestParam Long activityGroupBoardId
@@ -145,9 +145,9 @@ public class ActivityGroupBoardController {
         return ApiResponse.success(id);
     }
 
-    @GetMapping("/deleted")
     @Operation(summary = "[S] 삭제된 활동 그룹 게시판 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<ActivityGroupBoardResponseDto>> getDeletedActivityGroupBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,8 +39,9 @@ public class ActivityGroupMemberController {
     private final ActivityGroupMemberService activityGroupMemberService;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "활동 전체 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[U] 활동 전체 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -53,7 +54,8 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroups);
     }
 
-    @Operation(summary = "활동 상세 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @Operation(summary = "[U] 활동 상세 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{activityGroupId}")
     public ApiResponse<Object> getActivityGroup(
             @PathVariable(name = "activityGroupId") Long activityGroupId
@@ -63,7 +65,7 @@ public class ActivityGroupMemberController {
     }
 
     @Operation(summary = "[U] 나의 활동 목록 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getMyActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -75,7 +77,7 @@ public class ActivityGroupMemberController {
     }
 
     @Operation(summary = "[U] 활동 상태별 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/status")
     public ApiResponse<PagedResponseDto<ActivityGroupStatusResponseDto>> getActivityGroupsByStatus(
             @RequestParam(name = "activityGroupStatus") ActivityGroupStatus status,
@@ -87,8 +89,9 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroups);
     }
 
-    @Operation(summary = "카테고리별 활동 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[U] 카테고리별 활동 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/list")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getActivityGroupsByCategory(
             @RequestParam(name = "category") ActivityGroupCategory category,
@@ -104,7 +107,7 @@ public class ActivityGroupMemberController {
 
     @Operation(summary = "[U] 활동 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/schedule")
     public ApiResponse<PagedResponseDto<GroupScheduleDto>> getGroupScheduleList(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -121,7 +124,7 @@ public class ActivityGroupMemberController {
     @Operation(summary = "[U] 활동 멤버 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "활동에 참여(수락)된 멤버만 조회 가능<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/members")
     public ApiResponse<PagedResponseDto<GroupMemberResponseDto>> getActivityGroupMemberList(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -136,7 +139,7 @@ public class ActivityGroupMemberController {
     }
 
     @Operation(summary = "[U] 활동 신청", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/apply")
     public ApiResponse<Long> applyActivityGroup(
             @RequestParam Long activityGroupId,

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
@@ -39,9 +39,9 @@ public class ActivityGroupMemberController {
     private final ActivityGroupMemberService activityGroupMemberService;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 활동 전체 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 활동 전체 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -64,8 +64,8 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroup);
     }
 
-    @Operation(summary = "[U] 나의 활동 목록 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 나의 활동 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getMyActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -89,9 +89,9 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroups);
     }
 
-    @Operation(summary = "[U] 카테고리별 활동 목록 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 카테고리별 활동 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/list")
     public ApiResponse<PagedResponseDto<ActivityGroupResponseDto>> getActivityGroupsByCategory(
             @RequestParam(name = "category") ActivityGroupCategory category,
@@ -105,9 +105,9 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroups);
     }
 
-    @Operation(summary = "[U] 활동 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 활동 일정 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/schedule")
     public ApiResponse<PagedResponseDto<GroupScheduleDto>> getGroupScheduleList(
             @RequestParam(name = "activityGroupId") Long activityGroupId,

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupReportController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupReportController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,8 +39,8 @@ public class ActivityGroupReportController {
     private final PageableUtils pageableUtils;
 
     @Operation(summary = "[U] 활동 보고서 작성", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
     public ApiResponse<Long> writeReport(
             @Valid @RequestBody ActivityGroupReportRequestDto requestDto
     ) throws PermissionDeniedException, IllegalAccessException {
@@ -50,8 +50,8 @@ public class ActivityGroupReportController {
 
     @Operation(summary = "[U] 특정 그룹의 활동 보고서 전체 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
     public ApiResponse<PagedResponseDto<ActivityGroupReportResponseDto>> getReports(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -65,8 +65,8 @@ public class ActivityGroupReportController {
     }
 
     @Operation(summary = "[U] 특정 그룹의 특정 차시 활동 보고서 검색", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/search")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
     public ApiResponse<ActivityGroupReportResponseDto> searchReport(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "turn") Long turn
@@ -76,8 +76,8 @@ public class ActivityGroupReportController {
     }
 
     @Operation(summary = "[U] 활동 보고서 수정", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{reportId}")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
     public ApiResponse<Long> updateReport(
             @PathVariable(name = "reportId") Long reportId,
             @RequestParam(name = "activityGroupId") Long activityGroupId,
@@ -88,7 +88,7 @@ public class ActivityGroupReportController {
     }
 
     @Operation(summary = "[U] 활동보고서 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{reportId}")
     public ApiResponse<Long> deleteAward(
             @PathVariable(name = "reportId") Long reportId
@@ -98,9 +98,9 @@ public class ActivityGroupReportController {
     }
 
 
-    @GetMapping("/deleted")
     @Operation(summary = "[S] 삭제된 활동보고서 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<ActivityGroupReportResponseDto>> getDeletedActivityGroupReports(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/AttendanceController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/AttendanceController.java
@@ -58,9 +58,9 @@ public class AttendanceController {
         return ApiResponse.success(id);
     }
 
-    @Operation(summary = "[U] 내 출석기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 내 출석기록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping({ "/my-attendance" })
     public ApiResponse<PagedResponseDto<AttendanceResponseDto>> searchMyAttendance(
             @RequestParam(name = "activityGroupId", defaultValue = "1") Long activityGroupId,

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/AttendanceController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/AttendanceController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,7 +39,7 @@ public class AttendanceController {
     private final PageableUtils pageableUtils;
 
     @Operation(summary = "[U] 출석체크 QR 생성", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "")
     public ApiResponse<String> generateAttendanceQRCode(
             @RequestParam(name = "activityGroupId") Long activityGroupId
@@ -49,7 +49,7 @@ public class AttendanceController {
     }
 
     @Operation(summary = "[U] 출석 인증", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/check-in")
     public ApiResponse<Long> checkInAttendance(
             @RequestBody AttendanceRequestDto requestDto
@@ -60,7 +60,7 @@ public class AttendanceController {
 
     @Operation(summary = "[U] 내 출석기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping({ "/my-attendance" })
     public ApiResponse<PagedResponseDto<AttendanceResponseDto>> searchMyAttendance(
             @RequestParam(name = "activityGroupId", defaultValue = "1") Long activityGroupId,
@@ -76,7 +76,7 @@ public class AttendanceController {
 
     @Operation(summary = "[U] 특정 그룹의 출석기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping({ "/group-attendance" })
     public ApiResponse<PagedResponseDto<AttendanceResponseDto>> searchGroupAttendance(
             @RequestParam(name = "activityGroupId", defaultValue = "1") Long activityGroupId,
@@ -91,7 +91,7 @@ public class AttendanceController {
     }
 
     @Operation(summary = "[U] 불참 사유서 등록", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping({ "/absent" })
     public ApiResponse<Long> writeAbsentExcuse(
             @RequestBody AbsentRequestDto requestDto
@@ -102,7 +102,7 @@ public class AttendanceController {
 
     @Operation(summary = "[U] 그룹의 불참 사유서 열람", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping({ "/absent/{activityGroupId}" })
     public ApiResponse<PagedResponseDto<AbsentResponseDto>> getActivityGroupAbsentExcuses(
             @PathVariable(name = "activityGroupId") Long activityGroupId,

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/DeletedReviewsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/DeletedReviewsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedReviewsRetrievalController {
 
     private final RetrieveDeletedReviewsUseCase retrieveDeletedReviewsUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 리뷰 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<ReviewResponseDto>> retrieveDeletedReviews(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/MyReviewsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/MyReviewsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyReviewsRetrievalController {
 
     @Operation(summary = "[U] 나의 리뷰 목록", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<ReviewResponseDto>> retrieveMyReviews(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/MyReviewsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/MyReviewsRetrievalController.java
@@ -28,9 +28,9 @@ public class MyReviewsRetrievalController {
     private final RetrieveMyReviewsUseCase retrieveMyReviewsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 리뷰 목록", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 리뷰 목록", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<ReviewResponseDto>> retrieveMyReviews(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewRegisterController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class ReviewRegisterController {
     private final RegisterReviewUseCase registerReviewUseCase;
 
     @Operation(summary = "[U] 리뷰 등록", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> registerReview(
             @Valid @RequestBody ReviewRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewRemoveController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.activity.review.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class ReviewRemoveController {
     private final RemoveReviewUseCase removeReviewUseCase;
 
     @Operation(summary = "[U] 리뷰 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{reviewId}")
     public ApiResponse<Long> removeReview(
             @PathVariable(name = "reviewId") Long reviewId

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewUpdateController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class ReviewUpdateController {
     private final UpdateReviewUseCase updateReviewUseCase;
 
     @Operation(summary = "[U] 리뷰 수정", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{reviewId}")
     public ApiResponse<Long> updateReview(
             @PathVariable(name = "reviewId") Long reviewId,

--- a/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/activity/review/adapter/in/web/ReviewsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class ReviewsByConditionsRetrievalController {
             "4개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "멤버 ID, 멤버 이름, 활동 ID, 공개 여부 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ReviewResponseDto>> retrieveReviewsByConditions(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/BanMembersRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/BanMembersRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +24,7 @@ public class BanMembersRetrievalController {
     private final RetrieveBannedMembersUseCase retrieveBannedMembersUseCase;
 
     @Operation(summary = "[S] 밴 멤버 조회", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<AccountLockInfoResponseDto>> retrieveBanMembers(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/MemberBanController.java
+++ b/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/MemberBanController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class MemberBanController {
     private final BanMemberUseCase banMemberUseCase;
 
     @Operation(summary = "[S] 멤버 밴 등록", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("/ban/{memberId}")
     public ApiResponse<Long> banMember(
             HttpServletRequest request,

--- a/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/MemberUnbanController.java
+++ b/src/main/java/page/clab/api/domain/auth/accountLockInfo/adapter/in/web/MemberUnbanController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class MemberUnbanController {
     private final UnbanMemberUseCase unbanMemberUseCase;
 
     @Operation(summary = "[S] 멤버 밴 해제", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("/unban/{memberId}")
     public ApiResponse<Long> unbanMember(
             HttpServletRequest request,

--- a/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRegisterController.java
+++ b/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRegisterController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class BlacklistIpRegisterController {
     private final RegisterBlacklistIpUseCase registerBlacklistIpUseCase;
 
     @Operation(summary = "[S] 블랙리스트 IP 추가", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("")
     public ApiResponse<String> registerBlacklistIp(
             HttpServletRequest request,

--- a/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRemoveController.java
+++ b/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRemoveController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,7 +21,7 @@ public class BlacklistIpRemoveController {
     private final RemoveBlacklistIpUseCase removeBlacklistIpUseCase;
 
     @Operation(summary = "[S] 블랙리스트 IP 제거", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("")
     public ApiResponse<String> removeBlacklistIp(
             HttpServletRequest request,

--- a/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistIpRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class BlacklistIpRetrievalController {
 
     @Operation(summary = "[A] 블랙리스트 IP 목록 조회", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BlacklistIpResponseDto>> retrieveBlacklistIps(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistResetController.java
+++ b/src/main/java/page/clab/api/domain/auth/blacklistIp/adapter/in/web/BlacklistResetController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +22,7 @@ public class BlacklistResetController {
     private final ResetBlacklistIpsUseCase resetBlacklistIpsUseCase;
 
     @Operation(summary = "[S] 블랙리스트 IP 초기화", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/clear")
     public ApiResponse<List<String>> resetBlacklistIps(
             HttpServletRequest request

--- a/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/MemberLoginController.java
+++ b/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/MemberLoginController.java
@@ -46,4 +46,15 @@ public class MemberLoginController {
         response.setHeader(authHeader, result.getHeader());
         return ApiResponse.success(result.getBody());
     }
+
+    @Operation(summary = "Guest 로그인", description = "ROLE_ANONYMOUS 권한이 필요함")
+    @PostMapping("/guest")
+    public ApiResponse<Boolean> guestLogin(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        LoginResult result = manageLoginUseCase.guestLogin(request);
+        response.setHeader(authHeader, result.getHeader());
+        return ApiResponse.success(result.getBody());
+    }
 }

--- a/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TokenManagementController.java
+++ b/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TokenManagementController.java
@@ -6,7 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +36,7 @@ public class TokenManagementController {
 
     @Operation(summary = "[G] 토큰 재발급", description = "ROLE_GUEST 이상의 권한이 필요함")
     @PostMapping("/reissue")
-    @Secured({ "ROLE_GUEST", "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('GUEST')")
     public ApiResponse<Void> reissueToken(
             HttpServletRequest request,
             HttpServletResponse response
@@ -49,7 +49,7 @@ public class TokenManagementController {
     @Operation(summary = "[S] 현재 로그인 중인 멤버 조회", description = "ROLE_SUPER 이상의 권한이 필요함<br>" +
             "Redis에 저장된 토큰을 조회하여 현재 로그인 중인 멤버를 조회합니다.")
     @GetMapping("/current")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     public ApiResponse<List<String>> retrieveCurrentLoggedInUsers() {
         List<String> currentLoggedInUsers = manageLoginUseCase.retrieveCurrentLoggedInUsers();
         return ApiResponse.success(currentLoggedInUsers);

--- a/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TokenManagementController.java
+++ b/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TokenManagementController.java
@@ -34,9 +34,9 @@ public class TokenManagementController {
         this.authHeader = authHeader;
     }
 
-    @Operation(summary = "[U] 멤버 토큰 재발급", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[G] 토큰 재발급", description = "ROLE_GUEST 이상의 권한이 필요함")
     @PostMapping("/reissue")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @Secured({ "ROLE_GUEST", "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
     public ApiResponse<Void> reissueToken(
             HttpServletRequest request,
             HttpServletResponse response

--- a/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TwoFactorAuthenticationController.java
+++ b/src/main/java/page/clab/api/domain/auth/login/adapter/in/web/TwoFactorAuthenticationController.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,7 +52,7 @@ public class TwoFactorAuthenticationController {
 
     @Operation(summary = "[S] TOTP 초기화", description = "ROLE_SUPER 권한이 필요함")
     @DeleteMapping("/{memberId}")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     public ApiResponse<String> resetAuthenticator(
             @PathVariable(name = "memberId") String memberId
     ) {

--- a/src/main/java/page/clab/api/domain/auth/login/application/port/in/ManageLoginUseCase.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/port/in/ManageLoginUseCase.java
@@ -21,4 +21,6 @@ public interface ManageLoginUseCase {
     TokenHeader reissueToken(HttpServletRequest request);
 
     List<String> retrieveCurrentLoggedInUsers();
+
+    LoginResult guestLogin(HttpServletRequest request);
 }

--- a/src/main/java/page/clab/api/domain/auth/login/application/service/RedisTokenManagementService.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/service/RedisTokenManagementService.java
@@ -41,7 +41,7 @@ public class RedisTokenManagementService implements ManageRedisTokenUseCase {
         return StreamSupport.stream(iterableTokens.spliterator(), false)
                 .filter(Objects::nonNull)
                 .filter(redisToken -> jwtTokenProvider.validateTokenSilently(redisToken.getAccessToken()))
-                .map(RedisToken::getId)
+                .map(RedisToken::getMemberId)
                 .distinct()
                 .collect(Collectors.toList());
     }

--- a/src/main/java/page/clab/api/domain/auth/login/application/service/TokenManagementService.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/service/TokenManagementService.java
@@ -53,6 +53,11 @@ public class TokenManagementService implements ManageLoginUseCase {
         return manageRedisTokenUseCase.getCurrentLoggedInUsers();
     }
 
+    @Override
+    public LoginResult guestLogin(HttpServletRequest request) {
+        throw new UnsupportedOperationException("Method not implemented");
+    }
+
     private void validateMemberExistence(Authentication authentication) {
         String id = authentication.getName();
         if (!externalRetrieveMemberUseCase.existsById(id)) {

--- a/src/main/java/page/clab/api/domain/auth/login/application/service/TokenManagementService.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/service/TokenManagementService.java
@@ -43,8 +43,8 @@ public class TokenManagementService implements ManageLoginUseCase {
         validateMemberExistence(authentication);
         validateToken(redisToken);
 
-        TokenInfo newTokenInfo = jwtTokenProvider.generateToken(redisToken.getId(), redisToken.getRole());
-        manageRedisTokenUseCase.saveToken(redisToken.getId(), redisToken.getRole(), newTokenInfo, redisToken.getIp());
+        TokenInfo newTokenInfo = jwtTokenProvider.generateToken(redisToken.getMemberId(), redisToken.getRole());
+        manageRedisTokenUseCase.saveToken(redisToken.getMemberId(), redisToken.getRole(), newTokenInfo, redisToken.getIp());
         return TokenHeader.create(newTokenInfo);
     }
 

--- a/src/main/java/page/clab/api/domain/auth/login/application/service/TwoFactorAuthenticationService.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/service/TwoFactorAuthenticationService.java
@@ -96,4 +96,9 @@ public class TwoFactorAuthenticationService implements ManageLoginUseCase {
     public List<String> retrieveCurrentLoggedInUsers() {
         throw new UnsupportedOperationException("Method not implemented");
     }
+
+    @Override
+    public LoginResult guestLogin(HttpServletRequest request) {
+        throw new UnsupportedOperationException("Method not implemented");
+    }
 }

--- a/src/main/java/page/clab/api/domain/auth/login/application/service/UserLoginService.java
+++ b/src/main/java/page/clab/api/domain/auth/login/application/service/UserLoginService.java
@@ -57,6 +57,15 @@ public class UserLoginService implements ManageLoginUseCase {
         return generateLoginResult(loginMember);
     }
 
+    @Transactional
+    @Override
+    public LoginResult guestLogin(HttpServletRequest request) {
+        MemberLoginInfoDto guestMember = externalRetrieveMemberUseCase.getGuestMemberLoginInfo();
+        registerAccountAccessLogUseCase.registerAccountAccessLog(request, guestMember.getMemberId(), AccountAccessResult.SUCCESS);
+        externalUpdateMemberUseCase.updateLastLoginTime(guestMember.getMemberId());
+        return generateLoginResult(guestMember);
+    }
+
     private void authenticateAndCheckStatus(HttpServletRequest httpServletRequest, LoginRequestDto loginRequestDto) throws LoginFailedException, MemberLockedException {
         try {
             UsernamePasswordAuthenticationToken authenticationToken =

--- a/src/main/java/page/clab/api/domain/auth/login/domain/RedisToken.java
+++ b/src/main/java/page/clab/api/domain/auth/login/domain/RedisToken.java
@@ -1,6 +1,5 @@
 package page.clab.api.domain.auth.login.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -51,6 +50,6 @@ public class RedisToken {
     }
 
     public boolean isAdminToken() {
-        return role == Role.ADMIN || role == Role.SUPER;
+        return role.isHigherThan(Role.ADMIN);
     }
 }

--- a/src/main/java/page/clab/api/domain/auth/login/domain/RedisToken.java
+++ b/src/main/java/page/clab/api/domain/auth/login/domain/RedisToken.java
@@ -13,6 +13,8 @@ import org.springframework.data.redis.core.index.Indexed;
 import page.clab.api.domain.auth.login.application.dto.response.TokenInfo;
 import page.clab.api.domain.memberManagement.member.domain.Role;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @Builder
@@ -22,9 +24,8 @@ import page.clab.api.domain.memberManagement.member.domain.Role;
 public class RedisToken {
 
     @Id
-    @Column(name = "member_id")
-    private String id;
-
+    private UUID id;
+    private String memberId;
     private Role role;
     private String ip;
 
@@ -34,9 +35,10 @@ public class RedisToken {
     @Indexed
     private String refreshToken;
 
-    public static RedisToken create(String id, Role role, String ip, TokenInfo tokenInfo) {
+    public static RedisToken create(String memberId, Role role, String ip, TokenInfo tokenInfo) {
         return RedisToken.builder()
-                .id(id)
+                .id(UUID.randomUUID())
+                .memberId(memberId)
                 .role(role)
                 .ip(ip)
                 .accessToken(tokenInfo.getAccessToken())

--- a/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpRemoveController.java
+++ b/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpRemoveController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +22,7 @@ public class AbnormalAccessIpRemoveController {
 
     @Operation(summary = "[S] 비정상 접근 IP 기록 삭제", description = "ROLE_SUPER 이상의 권한이 필요함<br>" +
             "지속적인 비정상 접근으로 인해 차단된 IP를 삭제")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/abnormal-access")
     public ApiResponse<String> removeAbnormalAccessBlacklistIp(
             HttpServletRequest request,

--- a/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpsClearController.java
+++ b/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpsClearController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +24,7 @@ public class AbnormalAccessIpsClearController {
 
     @Operation(summary = "[S] 비정상 접근 IP 기록 초기화", description = "ROLE_SUPER 이상의 권한이 필요함<br>" +
             "지속적인 비정상 접근으로 인해 차단된 IP를 모두 삭제")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/abnormal-access/clear")
     public ApiResponse<List<RedisIpAccessMonitor>> clearAbnormalAccessBlacklist(
             HttpServletRequest request

--- a/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpsRetrieveController.java
+++ b/src/main/java/page/clab/api/domain/auth/redisIpAccessMonitor/adapter/in/web/AbnormalAccessIpsRetrieveController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,7 +25,7 @@ public class AbnormalAccessIpsRetrieveController {
 
     @Operation(summary = "[S] 비정상 접근으로 인한 차단 IP 목록 조회", description = "ROLE_SUPER 이상의 권한이 필요함<br>" +
             "지속적인 비정상 접근으로 인해 Redis에 추가된 IP를 조회")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/abnormal-access")
     public ApiResponse<PagedResponseDto<RedisIpAccessMonitor>> retrieveAbnormalAccessBlacklistIps(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationReportController.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationReportController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class AccusationReportController {
     private final ReportAccusationUseCase reportAccusationUsecase;
 
     @Operation(summary = "[U] 신고 접수", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> reportIncident(
             @Valid @RequestBody AccuseRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,7 +35,7 @@ public class AccusationRetrievalController {
             "신고 대상, 처리 상태 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "누적 횟수 기준으로 정렬할지 여부를 선택할 수 있음<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<AccuseResponseDto>> retrieveAccusations(
             @RequestParam(name = "targetType", required = false) TargetType type,

--- a/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationStatusController.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/AccusationStatusController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.accuse.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class AccusationStatusController {
     private final ChangeAccusationStatusUseCase changeAccusationStatusUsecase;
 
     @Operation(summary = "[A] 신고 상태 변경", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{targetType}/{targetId}")
     public ApiResponse<Long> changeAccusationStatus(
             @PathVariable(name = "targetType") TargetType type,

--- a/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/MyAccusationsController.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/MyAccusationsController.java
@@ -28,9 +28,9 @@ public class MyAccusationsController {
     private final RetrieveMyAccusationsUseCase retrieveMyAccusationsUsecase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 신고 내역 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 신고 내역 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<AccuseMyResponseDto>> retrieveMyAccusations(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/MyAccusationsController.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/adapter/in/web/MyAccusationsController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyAccusationsController {
 
     @Operation(summary = "[U] 나의 신고 내역 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<AccuseMyResponseDto>> retrieveMyAccusations(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardDetailsRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.board.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,9 +20,9 @@ public class BoardDetailsRetrievalController {
 
     private final RetrieveBoardDetailsUseCase retrieveBoardDetailsUseCase;
 
-    @GetMapping("/{boardId}")
     @Operation(summary = "[U] 커뮤니티 게시글 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/{boardId}")
     public ApiResponse<BoardDetailsResponseDto> retrieveBoardDetails(
             @PathVariable(name = "boardId") Long boardId
     ) {

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardEmojiToggleController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardEmojiToggleController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.board.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,9 +19,9 @@ public class BoardEmojiToggleController {
 
     private final ToggleBoardEmojiUseCase toggleBoardEmojiUseCase;
 
-    @PostMapping("/{boardId}/react/{emoji}")
     @Operation(summary = "[U] 커뮤니티 게시글 이모지 누르기/취소하기", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("/{boardId}/react/{emoji}")
     public ApiResponse<String> toggleEmojiStatus(
             @PathVariable(name = "boardId") Long boardId,
             @PathVariable(name = "emoji") String emoji

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardRegisterController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class BoardRegisterController {
     private final RegisterBoardUseCase registerBoardUseCase;
 
     @Operation(summary = "[U] 커뮤니티 게시글 생성", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<String> registerBoard(
             @Valid @RequestBody BoardRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardRemoveController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.board.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class BoardRemoveController {
     private final RemoveBoardUseCase removeBoardUseCase;
 
     @Operation(summary = "[U] 커뮤니티 게시글 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{boardId}")
     public ApiResponse<String> removeBoard(
             @PathVariable(name = "boardId") Long boardId

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardUpdateController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,9 +23,9 @@ public class BoardUpdateController {
 
     private final UpdateBoardUseCase updateBoardUseCase;
 
-    @PatchMapping("/{boardId}")
     @Operation(summary = "[U] 커뮤니티 게시글 수정", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("/{boardId}")
     public ApiResponse<String> updateBoard(
             @PathVariable(name = "boardId") Long boardId,
             @Valid @RequestBody BoardUpdateRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsByCategoryRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsByCategoryRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,10 +29,10 @@ public class BoardsByCategoryRetrievalController {
     private final RetrieveBoardsByCategoryUseCase retrieveBoardsByCategoryUseCase;
     private final PageableUtils pageableUtils;
 
-    @GetMapping("/category")
     @Operation(summary = "[U] 커뮤니티 게시글 카테고리별 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/category")
     public ApiResponse<PagedResponseDto<BoardCategoryResponseDto>> retrieveBoardsByCategory(
             @RequestParam(name = "category") BoardCategory category,
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsByCategoryRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsByCategoryRetrievalController.java
@@ -29,9 +29,9 @@ public class BoardsByCategoryRetrievalController {
     private final RetrieveBoardsByCategoryUseCase retrieveBoardsByCategoryUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 커뮤니티 게시글 카테고리별 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 커뮤니티 게시글 카테고리별 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/category")
     public ApiResponse<PagedResponseDto<BoardCategoryResponseDto>> retrieveBoardsByCategory(
             @RequestParam(name = "category") BoardCategory category,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsRetrievalController.java
@@ -28,9 +28,9 @@ public class BoardsRetrievalController {
     private final RetrieveBoardUseCase retrieveBoardUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 커뮤니티 게시글 목록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 커뮤니티 게시글 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BoardListResponseDto>> retrieveBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,10 +28,10 @@ public class BoardsRetrievalController {
     private final RetrieveBoardUseCase retrieveBoardUseCase;
     private final PageableUtils pageableUtils;
 
-    @GetMapping("")
     @Operation(summary = "[U] 커뮤니티 게시글 목록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("")
     public ApiResponse<PagedResponseDto<BoardListResponseDto>> retrieveBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/DeletedBoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/DeletedBoardsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedBoardsRetrievalController {
 
     private final RetrieveDeletedBoardsUseCase retrieveDeletedBoardsUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 커뮤니티 게시글 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<BoardListResponseDto>> retrieveDeletedBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/MyBoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/MyBoardsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyBoardsRetrievalController {
 
     @Operation(summary = "[U] 내가 쓴 커뮤니티 게시글 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-boards")
     public ApiResponse<PagedResponseDto<BoardMyResponseDto>> retrieveMyBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/MyBoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/MyBoardsRetrievalController.java
@@ -28,9 +28,9 @@ public class MyBoardsRetrievalController {
     private final RetrieveMyBoardsUseCase retrieveMyBoardsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 내가 쓴 커뮤니티 게시글 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 내가 쓴 커뮤니티 게시글 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my-boards")
     public ApiResponse<PagedResponseDto<BoardMyResponseDto>> retrieveMyBoards(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentLikeToggleController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentLikeToggleController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.comment.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class CommentLikeToggleController {
     private final ToggleCommentLikeUseCase toggleCommentLikeUseCase;
 
     @Operation(summary = "[U] 댓글 좋아요 누르기/취소하기", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/likes/{commentId}")
     public ApiResponse<Long> toggleLikeStatus(
             @PathVariable(name = "commentId") Long commentId

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRegisterController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class CommentRegisterController {
     private final RegisterCommentUseCase registerCommentUseCase;
 
     @Operation(summary = "[U] 댓글 생성", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{boardId}")
     public ApiResponse<Long> registerComment(
             @RequestParam(name = "parentId", required = false) Long parentId,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRemoveController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.comment.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class CommentRemoveController {
     private final RemoveCommentUseCase removeCommentUseCase;
 
     @Operation(summary = "[U] 댓글 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{commentId}")
     public ApiResponse<Long> removeComment(
             @PathVariable(name = "commentId") Long commentId

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +31,7 @@ public class CommentRetrievalController {
 
     @Operation(summary = "[U] 댓글 목록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{boardId}")
     public ApiResponse<PagedResponseDto<CommentResponseDto>> retrieveComments(
             @PathVariable(name = "boardId") Long boardId,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentUpdateController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class CommentUpdateController {
     private final UpdateCommentUseCase updateCommentUseCase;
 
     @Operation(summary = "[U] 댓글 수정", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{commentId}")
     public ApiResponse<Long> updateComment(
             @PathVariable(name = "commentId") Long commentId,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/DeletedCommentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/DeletedCommentsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +25,7 @@ public class DeletedCommentsRetrievalController {
     private final RetrieveDeletedCommentsUseCase retrieveDeletedCommentsUseCase;
 
     @Operation(summary = "[S] 게시글의 삭제된 댓글 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/deleted/{boardId}")
     public ApiResponse<PagedResponseDto<DeletedCommentResponseDto>> retrieveDeletedComments(
             @PathVariable(name = "boardId") Long boardId,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/MyCommentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/MyCommentsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyCommentsRetrievalController {
 
     @Operation(summary = "[U] 나의 댓글 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-comments")
     public ApiResponse<PagedResponseDto<CommentMyResponseDto>> retrieveMyComments(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/MyCommentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/MyCommentsRetrievalController.java
@@ -28,9 +28,9 @@ public class MyCommentsRetrievalController {
     private final RetrieveMyCommentsUseCase retrieveMyCommentsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 댓글 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 댓글 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my-comments")
     public ApiResponse<PagedResponseDto<CommentMyResponseDto>> retrieveMyComments(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingDetailsRetrievalController.java
@@ -20,8 +20,8 @@ public class JobPostingDetailsRetrievalController {
 
     private final RetrieveJobPostingDetailsUseCase retrieveJobPostingDetailsUseCase;
 
-    @Operation(summary = "[U] 채용 공고 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 채용 공고 상세 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/{jobPostingId}")
     public ApiResponse<JobPostingDetailsResponseDto> retrieveJobPostingDetails(
             @PathVariable(name = "jobPostingId") Long jobPostingId

--- a/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingDetailsRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.jobPosting.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class JobPostingDetailsRetrievalController {
     private final RetrieveJobPostingDetailsUseCase retrieveJobPostingDetailsUseCase;
 
     @Operation(summary = "[U] 채용 공고 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{jobPostingId}")
     public ApiResponse<JobPostingDetailsResponseDto> retrieveJobPostingDetails(
             @PathVariable(name = "jobPostingId") Long jobPostingId

--- a/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,7 +34,7 @@ public class JobPostingsByConditionsRetrievalController {
             "4개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "공고명, 기업명, 경력, 근로 조건 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<JobPostingResponseDto>> retrieveJobPostingsByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/jobPosting/adapter/in/web/JobPostingsByConditionsRetrievalController.java
@@ -30,11 +30,11 @@ public class JobPostingsByConditionsRetrievalController {
     private final RetrieveJobPostingsByConditionsUseCase retrieveJobPostingsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 채용 공고 목록 조회(공고명, 기업명, 경력, 근로 조건 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 채용 공고 목록 조회(공고명, 기업명, 경력, 근로 조건 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "4개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "공고명, 기업명, 경력, 근로 조건 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<JobPostingResponseDto>> retrieveJobPostingsByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsByConditionsRetrievalController.java
@@ -28,11 +28,11 @@ public class NewsByConditionsRetrievalController {
     private final RetrieveNewsByConditionsUseCase retrieveNewsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 뉴스 목록 조회(제목, 카테고리 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 뉴스 목록 조회(제목, 카테고리 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 카테고리 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<NewsResponseDto>> retrieveNewsByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class NewsByConditionsRetrievalController {
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 카테고리 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<NewsResponseDto>> retrieveNewsByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsDetailsRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.community.news.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class NewsDetailsRetrievalController {
     private final RetrieveNewsDetailsUseCase retrieveNewsDetailsUseCase;
 
     @Operation(summary = "[U] 뉴스 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{newsId}")
     public ApiResponse<NewsDetailsResponseDto> retrieveNewsDetails(
             @PathVariable(name = "newsId") Long newsId

--- a/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/news/adapter/in/web/NewsDetailsRetrievalController.java
@@ -20,8 +20,8 @@ public class NewsDetailsRetrievalController {
 
     private final RetrieveNewsDetailsUseCase retrieveNewsDetailsUseCase;
 
-    @Operation(summary = "[U] 뉴스 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 뉴스 상세 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/{newsId}")
     public ApiResponse<NewsDetailsResponseDto> retrieveNewsDetails(
             @PathVariable(name = "newsId") Long newsId

--- a/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationApprovalToggleController.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationApprovalToggleController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.hiring.application.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class ApplicationApprovalToggleController {
 
     @Operation(summary = "[S] 지원 합격/취소", description = "ROLE_SUPER 이상의 권한이 필요함<br>" +
             "승인/취소 상태가 반전됨")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PatchMapping("/{recruitmentId}/{studentId}")
     public ApiResponse<String> toggleApprovalStatus(
             @PathVariable(name = "recruitmentId") Long recruitmentId,

--- a/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationMemberRegisterController.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationMemberRegisterController.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.hiring.application.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ public class ApplicationMemberRegisterController {
     private final RegisterMembersByRecruitmentUseCase registerMembersByRecruitmentUseCase;
 
     @Operation(summary = "[S] 모집 단위별 합격자 멤버 통합 생성", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("/{recruitmentId}")
     public ApiResponse<List<String>> registerMembersByRecruitment(
             @PathVariable(name = "recruitmentId") Long recruitmentId
@@ -30,6 +32,7 @@ public class ApplicationMemberRegisterController {
     }
 
     @Operation(summary = "[S] 모집 단위별 합격자 멤버 개별 생성", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("/{recruitmentId}/{studentId}")
     public ApiResponse<String> registerMembersByRecruitment(
             @PathVariable(name = "recruitmentId") Long recruitmentId,

--- a/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/adapter/in/web/ApplicationRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class ApplicationRetrievalController {
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "모집 일정 ID, 지원자 ID, 합격 여부 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<ApplicationResponseDto>> retrieveApplicationsByConditions(
             @RequestParam(name = "recruitmentId", required = false) Long recruitmentId,

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRegisterController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class RecruitmentRegisterController {
     private final RegisterRecruitmentUseCase registerRecruitmentUseCase;
 
     @Operation(summary = "[S] 모집 공고 등록", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("")
     public ApiResponse<Long> registerRecruitment(
             @Valid @RequestBody RecruitmentRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentUpdateController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +23,7 @@ public class RecruitmentUpdateController {
     private final UpdateRecruitmentUseCase updateRecruitmentUseCase;
 
     @Operation(summary = "[S] 모집 공고 수정", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PatchMapping("/{recruitmentId}")
     public ApiResponse<Long> updateRecruitment(
             @PathVariable(name = "recruitmentId") Long recruitmentId,

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookDetailsRetrievalController.java
@@ -20,8 +20,8 @@ public class BookDetailsRetrievalController {
 
     private final RetrieveBookDetailsUseCase retrieveBookDetailsUseCase;
 
-    @Operation(summary = "[U] 도서 상세 정보", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 도서 상세 정보", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/{bookId}")
     public ApiResponse<BookDetailsResponseDto> retrieveBookDetails(
             @PathVariable(name = "bookId") Long bookId

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookDetailsRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.library.book.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class BookDetailsRetrievalController {
     private final RetrieveBookDetailsUseCase retrieveBookDetailsUseCase;
 
     @Operation(summary = "[U] 도서 상세 정보", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{bookId}")
     public ApiResponse<BookDetailsResponseDto> retrieveBookDetails(
             @PathVariable(name = "bookId") Long bookId

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookRegisterController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class BookRegisterController {
     private final RegisterBookUseCase registerBookUseCase;
 
     @Operation(summary = "[A] 도서 등록", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<Long> registerBook(
             @Valid @RequestBody BookRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookRemoveController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.library.book.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class BookRemoveController {
     private final RemoveBookUseCase removeBookUseCase;
 
     @Operation(summary = "[A] 도서 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{bookId}")
     public ApiResponse<Long> removeBook(
             @PathVariable(name = "bookId") Long bookId

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookUpdateController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BookUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class BookUpdateController {
     private final UpdateBookUseCase updateBookUseCase;
 
     @Operation(summary = "[A] 도서 정보 수정", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("")
     public ApiResponse<Long> updateBookInfo(
             @RequestParam(name = "bookId") Long bookId,

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BooksByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BooksByConditionsRetrievalController.java
@@ -28,11 +28,11 @@ public class BooksByConditionsRetrievalController {
     private final RetrieveBooksByConditionsUseCase retrieveBooksByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 도서 목록 조회(제목, 카테고리, 출판사, 대여자 ID, 대여자 이름 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 도서 목록 조회(제목, 카테고리, 출판사, 대여자 ID, 대여자 이름 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "5개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 카테고리, 출판사, 대여자 ID, 대여자 이름 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BookResponseDto>> retrieveBooksByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BooksByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/book/adapter/in/web/BooksByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class BooksByConditionsRetrievalController {
             "5개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 카테고리, 출판사, 대여자 ID, 대여자 이름 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BookResponseDto>> retrieveBooksByConditions(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanApprovalController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanApprovalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.library.bookLoanRecord.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class BookLoanApprovalController {
     private final ApproveBookLoanUseCase approveBookLoanUseCase;
 
     @Operation(summary = "[A] 도서 대출 승인", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/approve/{bookLoanRecordId}")
     public ApiResponse<Long> approveBookLoan(
             @PathVariable(name = "bookLoanRecordId") Long bookLoanRecordId

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanExtensionController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanExtensionController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class BookLoanExtensionController {
     private final ExtendBookLoanUseCase extendBookLoanUseCase;
 
     @Operation(summary = "[U] 도서 대출 연장", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/extend")
     public ApiResponse<Long> extendBookLoan(
             @Valid @RequestBody BookLoanRecordRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRecordsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRecordsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +33,7 @@ public class BookLoanRecordsByConditionsRetrievalController {
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "도서 ID, 대출자 ID, 대출 가능 여부 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<BookLoanRecordResponseDto>> retrieveBookLoanRecordsByConditions(
             @RequestParam(name = "bookId", required = false) Long bookId,

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRecordsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRecordsByConditionsRetrievalController.java
@@ -29,11 +29,11 @@ public class BookLoanRecordsByConditionsRetrievalController {
     private final RetrieveBookLoanRecordsByConditionsUseCase retrieveBookLoanRecordsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 도서 대출 내역 조회(도서 ID, 대출자 ID, 대출 상태 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 도서 대출 내역 조회(도서 ID, 대출자 ID, 대출 상태 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "도서 ID, 대출자 ID, 대출 가능 여부 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<BookLoanRecordResponseDto>> retrieveBookLoanRecordsByConditions(
             @RequestParam(name = "bookId", required = false) Long bookId,

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRejectionController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRejectionController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.library.bookLoanRecord.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class BookLoanRejectionController {
     private final RejectBookLoanUseCase rejectBookLoanUseCase;
 
     @Operation(summary = "[A] 도서 대출 거절", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/reject/{bookLoanRecordId}")
     public ApiResponse<Long> rejectBookLoan(
             @PathVariable(name = "bookLoanRecordId") Long bookLoanRecordId

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRequestController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanRequestController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class BookLoanRequestController {
     private final RequestBookLoanUseCase requestBookLoanUseCase;
 
     @Operation(summary = "[U] 도서 대출 요청", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> requestBookLoan(
             @Valid @RequestBody BookLoanRecordRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookReturnController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookReturnController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class BookReturnController {
     private final ReturnBookUseCase returnBookUseCase;
 
     @Operation(summary = "[U] 도서 반납", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/return")
     public ApiResponse<Long> returnBook(
             @Valid @RequestBody BookLoanRecordRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/OverdueBookLoanRecordsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/OverdueBookLoanRecordsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class OverdueBookLoanRecordsRetrievalController {
 
     @Operation(summary = "[A] 도서 연체자 조회", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/overdue")
     public ApiResponse<PagedResponseDto<BookLoanRecordOverdueResponseDto>> retrieveOverdueBookLoanRecords(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRegisterController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class AwardRegisterController {
     private final RegisterAwardUseCase registerAwardUseCase;
 
     @Operation(summary = "[U] 수상 이력 등록", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> registerAward(
             @Valid @RequestBody AwardRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRemoveController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.memberManagement.award.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class AwardRemoveController {
 
     @Operation(summary = "[U] 수상 이력 삭제", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{awardId}")
     public ApiResponse<Long> removeAward(
             @PathVariable(name = "awardId") Long awardId

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRetrievalController.java
@@ -28,11 +28,11 @@ public class AwardRetrievalController {
     private final RetrieveAwardsUseCase retrieveAwardsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 수상 이력 조회(학번, 연도 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 수상 이력 조회(학번, 연도 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "학번, 연도 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<AwardResponseDto>> retrieveAwards(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class AwardRetrievalController {
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "학번, 연도 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<AwardResponseDto>> retrieveAwards(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardUpdateController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/AwardUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +25,7 @@ public class AwardUpdateController {
 
     @Operation(summary = "[U] 수상 이력 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{awardId}")
     public ApiResponse<Long> updateAward(
             @PathVariable(name = "awardId") Long awardId,

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/DeletedAwardRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/DeletedAwardRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedAwardRetrievalController {
 
     private final RetrieveDeletedAwardsUseCase retrieveDeletedAwardsUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 수상이력 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<AwardResponseDto>> retrieveDeletedAwards(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/MyAwardRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/MyAwardRetrievalController.java
@@ -28,9 +28,9 @@ public class MyAwardRetrievalController {
     private final RetrieveMyAwardsUseCase retrieveMyAwardsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 수상 이력 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 수상 이력 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<AwardResponseDto>> retrieveMyAwards(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/MyAwardRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/award/adapter/in/web/MyAwardRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyAwardRetrievalController {
 
     @Operation(summary = "[U] 나의 수상 이력 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<AwardResponseDto>> retrieveMyAwards(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalAllController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalAllController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +24,7 @@ public class CloudUsageRetrievalAllController {
     private final RetrieveAllCloudUsageUseCase retrieveAllCloudUsageUseCase;
 
     @Operation(summary = "[S] 모든 멤버의 클라우드 사용량 조회", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<CloudUsageInfo>> retrieveAllCloudUsages(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalByMemberIdController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalByMemberIdController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.memberManagement.cloud.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class CloudUsageRetrievalByMemberIdController {
 
     @Operation(summary = "[U] 멤버의 클라우드 사용량 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{memberId}")
     public ApiResponse<CloudUsageInfo> retrieveCloudUsageByMemberId(
             @PathVariable(name = "memberId") String memberId

--- a/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalByMemberIdController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/CloudUsageRetrievalByMemberIdController.java
@@ -21,9 +21,9 @@ public class CloudUsageRetrievalByMemberIdController {
 
     private final RetrieveCloudUsageByMemberIdUseCase retrieveCloudUsageByMemberIdUseCase;
 
-    @Operation(summary = "[U] 멤버의 클라우드 사용량 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 멤버의 클라우드 사용량 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/{memberId}")
     public ApiResponse<CloudUsageInfo> retrieveCloudUsageByMemberId(
             @PathVariable(name = "memberId") String memberId

--- a/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/FilesInMemberDirectoryRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/cloud/adapter/in/web/FilesInMemberDirectoryRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +26,7 @@ public class FilesInMemberDirectoryRetrievalController {
 
     @Operation(summary = "[U] 멤버 업로드 파일 리스트 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 정보만 조회 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/files/{memberId}")
     public ApiResponse<PagedResponseDto<FileInfo>> retrieveFilesInMemberDirectory(
             @PathVariable(name = "memberId") String memberId,

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberBirthdayRetrievalThisMonthController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberBirthdayRetrievalThisMonthController.java
@@ -28,9 +28,9 @@ public class MemberBirthdayRetrievalThisMonthController {
     private final RetrieveMemberBirthdaysThisMonthUseCase retrieveMemberBirthdaysThisMonthUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 이달의 생일자 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 이달의 생일자 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/birthday")
     public ApiResponse<PagedResponseDto<MemberBirthdayResponseDto>> retrieveBirthdaysThisMonth(
             @RequestParam(name = "month") int month,

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberBirthdayRetrievalThisMonthController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberBirthdayRetrievalThisMonthController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,8 +28,9 @@ public class MemberBirthdayRetrievalThisMonthController {
     private final RetrieveMemberBirthdaysThisMonthUseCase retrieveMemberBirthdaysThisMonthUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "이달의 생일자 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[U] 이달의 생일자 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/birthday")
     public ApiResponse<PagedResponseDto<MemberBirthdayResponseDto>> retrieveBirthdaysThisMonth(
             @RequestParam(name = "month") int month,

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberInfoUpdateController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberInfoUpdateController.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.memberManagement.member.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,7 @@ public class MemberInfoUpdateController {
 
     @Operation(summary = "[U] 멤버 정보 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{memberId}")
     public ApiResponse<String> updateMemberInfo(
             @PathVariable(name = "memberId") String memberId,

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRegisterController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRegisterController.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.memberManagement.member.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ public class MemberRegisterController {
     private final RegisterMemberUseCase registerMemberUseCase;
 
     @Operation(summary = "[S] 신규 멤버 생성", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("")
     public ApiResponse<String> registerMember(
             @RequestBody MemberRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRemoveController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRemoveController.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.memberManagement.member.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ public class MemberRemoveController {
     private final RemoveMemberUseCase removeMemberUseCase;
 
     @Operation(summary = "[S] 멤버 정보 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/{memberId}")
     public ApiResponse<String> removeMember(
             @PathVariable(name = "memberId") String memberId

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MembersByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MembersByConditionsRetrievalController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,6 +30,7 @@ public class MembersByConditionsRetrievalController {
 
     @Operation(summary = "[A] 멤버 정보 조회(멤버 ID, 이름 기준)", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<MemberResponseDto>> retrieveMembersByConditions(
             @RequestParam(name = "id", required = false) String id,

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MyProfileRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MyProfileRetrievalController.java
@@ -19,8 +19,8 @@ public class MyProfileRetrievalController {
 
     private final RetrieveMyProfileUseCase retrieveMyProfileUseCase;
 
-    @Operation(summary = "[U] 내 프로필 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 내 프로필 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my-profile")
     public ApiResponse<MyProfileResponseDto> retrieveMyProfile() {
         MyProfileResponseDto myProfile = retrieveMyProfileUseCase.retrieveMyProfile();

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MyProfileRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MyProfileRetrievalController.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.memberManagement.member.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ public class MyProfileRetrievalController {
     private final RetrieveMyProfileUseCase retrieveMyProfileUseCase;
 
     @Operation(summary = "[U] 내 프로필 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-profile")
     public ApiResponse<MyProfileResponseDto> retrieveMyProfile() {
         MyProfileResponseDto myProfile = retrieveMyProfileUseCase.retrieveMyProfile();

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -9,6 +9,7 @@ import page.clab.api.domain.memberManagement.member.application.port.out.Registe
 import page.clab.api.domain.memberManagement.member.application.port.out.RetrieveMemberPort;
 import page.clab.api.domain.memberManagement.member.application.port.out.UpdateMemberPort;
 import page.clab.api.domain.memberManagement.member.domain.Member;
+import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.global.exception.NotFoundException;
 
 import java.util.List;
@@ -58,6 +59,13 @@ public class MemberPersistenceAdapter implements
     public Page<Member> findByConditions(String id, String name, Pageable pageable) {
         Page<MemberJpaEntity> jpaEntities = memberRepository.findByConditions(id, name, pageable);
         return jpaEntities.map(memberMapper::toDomainEntity);
+    }
+
+    @Override
+    public Member findFirstByRoleOrThrow(Role role) {
+        MemberJpaEntity jpaEntity = memberRepository.findFirstByRole(role)
+                .orElseThrow(() -> new NotFoundException("[Member] role: " + role + "에 해당하는 회원이 존재하지 않습니다."));
+        return memberMapper.toDomainEntity(jpaEntity);
     }
 
     @Override

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepository.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
+import page.clab.api.domain.memberManagement.member.domain.Role;
 
 import java.util.Optional;
 
@@ -18,4 +19,6 @@ public interface MemberRepository extends JpaRepository<MemberJpaEntity, String>
     Optional<MemberJpaEntity> findByEmail(String email);
 
     Page<MemberJpaEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Optional<MemberJpaEntity> findFirstByRole(Role role);
 }

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/port/out/RetrieveMemberPort.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/port/out/RetrieveMemberPort.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.memberManagement.member.application.port.out;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import page.clab.api.domain.memberManagement.member.domain.Member;
+import page.clab.api.domain.memberManagement.member.domain.Role;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,6 @@ public interface RetrieveMemberPort {
     Page<Member> findBirthdaysThisMonth(int month, Pageable pageable);
 
     Page<Member> findByConditions(String id, String name, Pageable pageable);
+
+    Member findFirstByRoleOrThrow(Role role);
 }

--- a/src/main/java/page/clab/api/domain/memberManagement/member/domain/Member.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/domain/Member.java
@@ -71,26 +71,6 @@ public class Member implements UserDetails {
         return password;
     }
 
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
-
     public void update(MemberUpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {
         Optional.ofNullable(requestDto.getPassword())
                 .ifPresent(password -> setPassword(passwordEncoder.encode(password)));

--- a/src/main/java/page/clab/api/domain/memberManagement/member/domain/Member.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/domain/Member.java
@@ -57,11 +57,6 @@ public class Member implements UserDetails {
     }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(getRole().getKey()));
-    }
-
-    @Override
     public String getUsername() {
         return id;
     }
@@ -69,6 +64,11 @@ public class Member implements UserDetails {
     @Override
     public String getPassword() {
         return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(getRole().getKey()));
     }
 
     public void update(MemberUpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {

--- a/src/main/java/page/clab/api/domain/memberManagement/member/domain/Role.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/domain/Role.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Role {
 
+    GUEST("ROLE_GUEST", "Guest User"),
     USER("ROLE_USER", "Normal User"),
     ADMIN("ROLE_ADMIN", "Administrator"),
     SUPER("ROLE_SUPER", "Super Administrator");
@@ -16,6 +17,7 @@ public enum Role {
 
     public Long toRoleLevel() {
         return switch (this) {
+            case GUEST -> 0L;
             case USER -> 1L;
             case ADMIN -> 2L;
             case SUPER -> 3L;

--- a/src/main/java/page/clab/api/domain/memberManagement/member/domain/Role.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/domain/Role.java
@@ -23,4 +23,8 @@ public enum Role {
             case SUPER -> 3L;
         };
     }
+
+    public boolean isHigherThan(Role role) {
+        return this.toRoleLevel() > role.toRoleLevel();
+    }
 }

--- a/src/main/java/page/clab/api/domain/memberManagement/notification/adapter/in/web/NotificationsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/notification/adapter/in/web/NotificationsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class NotificationsRetrievalController {
 
     @Operation(summary = "[U] 나의 알림 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<NotificationResponseDto>> retrieveNotifications(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/notification/adapter/in/web/NotificationsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/notification/adapter/in/web/NotificationsRetrievalController.java
@@ -28,9 +28,9 @@ public class NotificationsRetrievalController {
     private final RetrieveNotificationsUseCase retrieveNotificationsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 알림 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 알림 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<NotificationResponseDto>> retrieveNotifications(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/MyPositionsByYearRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/MyPositionsByYearRetrievalController.java
@@ -20,8 +20,8 @@ public class MyPositionsByYearRetrievalController {
 
     private final RetrieveMyPositionsByYearUseCase retrieveMyPositionsByYearUseCase;
 
-    @Operation(summary = "[U] 나의 직책 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 나의 직책 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my-positions")
     public ApiResponse<PositionMyResponseDto> retrieveMyPositionsByYear(
             @RequestParam(name = "year", required = false) String year

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/MyPositionsByYearRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/MyPositionsByYearRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.memberManagement.position.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,7 +21,7 @@ public class MyPositionsByYearRetrievalController {
     private final RetrieveMyPositionsByYearUseCase retrieveMyPositionsByYearUseCase;
 
     @Operation(summary = "[U] 나의 직책 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-positions")
     public ApiResponse<PositionMyResponseDto> retrieveMyPositionsByYear(
             @RequestParam(name = "year", required = false) String year

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionRegisterController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class PositionRegisterController {
     private final RegisterPositionUseCase registerPositionUseCase;
 
     @Operation(summary = "[S] 직책 등록", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("")
     public ApiResponse<Long> registerPosition(
             @Valid @RequestBody PositionRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionRemoveController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.memberManagement.position.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class PositionRemoveController {
     private final RemovePositionUseCase removePositionUseCase;
 
     @Operation(summary = "[S] 직책 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/{positionId}")
     public ApiResponse<Long> removePosition(
             @PathVariable("positionId") Long positionId

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +33,7 @@ public class PositionsByConditionsRetrievalController {
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "연도, 직책 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<PositionResponseDto>> retrievePositionsByConditions(
             @RequestParam(name = "year", required = false) String year,

--- a/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/position/adapter/in/web/PositionsByConditionsRetrievalController.java
@@ -29,11 +29,11 @@ public class PositionsByConditionsRetrievalController {
     private final RetrievePositionsByConditionsUseCase retrievePositionsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 연도/직책별 목록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 연도/직책별 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "연도, 직책 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<PositionResponseDto>> retrievePositionsByConditions(
             @RequestParam(name = "year", required = false) String year,

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/DeletedWorkExperiencesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/DeletedWorkExperiencesRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedWorkExperiencesRetrievalController {
 
     private final RetrieveDeletedWorkExperiencesUseCase retrieveDeletedWorkExperiencesUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 경력사항 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<WorkExperienceResponseDto>> retrieveDeletedWorkExperiences(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/MyWorkExperienceRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/MyWorkExperienceRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +31,7 @@ public class MyWorkExperienceRetrievalController {
     @Operation(summary = "[U] 나의 경력사항 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "입사일을 기준으로 내림차순 정렬하여 결과를 보여줌<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<WorkExperienceResponseDto>> retrieveMyWorkExperience(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/MyWorkExperienceRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/MyWorkExperienceRetrievalController.java
@@ -28,10 +28,10 @@ public class MyWorkExperienceRetrievalController {
     private final RetrieveMyWorkExperienceUseCase retrieveMyWorkExperienceUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 경력사항 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 경력사항 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "입사일을 기준으로 내림차순 정렬하여 결과를 보여줌<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<WorkExperienceResponseDto>> retrieveMyWorkExperience(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceRegisterController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class WorkExperienceRegisterController {
     private final RegisterWorkExperienceUseCase registerWorkExperienceUseCase;
 
     @Operation(summary = "[U] 경력사항 등록", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> registerWorkExperience(
             @Valid @RequestBody WorkExperienceRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceRemoveController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.memberManagement.workExperience.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class WorkExperienceRemoveController {
 
     @Operation(summary = "[U] 경력사항 삭제", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{workExperienceId}")
     public ApiResponse<Long> removeWorkExperience(
             @PathVariable(name = "workExperienceId") Long workExperienceId

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceUpdateController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperienceUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +25,7 @@ public class WorkExperienceUpdateController {
 
     @Operation(summary = "[U] 경력사항 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{workExperienceId}")
     public ApiResponse<Long> updateWorkExperience(
             @PathVariable(name = "workExperienceId") Long workExperienceId,

--- a/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperiencesByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/workExperience/adapter/in/web/WorkExperiencesByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +31,7 @@ public class WorkExperiencesByConditionsRetrievalController {
     @Operation(summary = "[U] 멤버의 경력사항 검색", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "입사일을 기준으로 내림차순 정렬하여 결과를 보여줌<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<WorkExperienceResponseDto>> retrieveWorkExperiencesByConditions(
             @RequestParam String memberId,

--- a/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class ActivityPhotoRegisterController {
     private final RegisterActivityPhotoUseCase registerActivityPhotoUseCase;
 
     @Operation(summary = "[A] 활동 사진 등록", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<Long> registerActivityPhoto(
             @Valid @RequestBody ActivityPhotoRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.activityPhoto.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +20,7 @@ public class ActivityPhotoRemoveController {
     private final RemoveActivityPhotoUseCase removeActivityPhotoUseCase;
 
     @Operation(summary = "[A] 활동 사진 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{activityPhotoId}")
     public ApiResponse<Long> removeActivityPhoto(
             @PathVariable(name = "activityPhotoId") Long activityPhotoId

--- a/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoVisibilityController.java
+++ b/src/main/java/page/clab/api/domain/members/activityPhoto/adapter/in/web/ActivityPhotoVisibilityController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.activityPhoto.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +19,8 @@ public class ActivityPhotoVisibilityController {
 
     private final ToggleActivityPhotoVisibilityUseCase toggleActivityPhotoVisibilityUseCase;
 
-    @Operation(summary = "활동 사진 고정/해제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @Operation(summary = "[A] 활동 사진 고정/해제", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{activityPhotoId}")
     public ApiResponse<Long> toggleActivityPhotoVisibility(
             @PathVariable(name = "activityPhotoId") Long activityPhotoId

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogDetailsRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.blog.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class BlogDetailsRetrievalController {
     private final RetrieveBlogDetailsUseCase retrieveBlogDetailsUseCase;
 
     @Operation(summary = "[U] 블로그 포스트 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{blogId}")
     public ApiResponse<BlogDetailsResponseDto> retrieveBlogDetails(
             @PathVariable(name = "blogId") Long blogId

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogDetailsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogDetailsRetrievalController.java
@@ -20,8 +20,8 @@ public class BlogDetailsRetrievalController {
 
     private final RetrieveBlogDetailsUseCase retrieveBlogDetailsUseCase;
 
-    @Operation(summary = "[U] 블로그 포스트 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 블로그 포스트 상세 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/{blogId}")
     public ApiResponse<BlogDetailsResponseDto> retrieveBlogDetails(
             @PathVariable(name = "blogId") Long blogId

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class BlogRegisterController {
     private final RegisterBlogUseCase registerBlogUseCase;
 
     @Operation(summary = "[A] 블로그 포스트 생성", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<Long> registerBlog(
             @Valid @RequestBody BlogRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.blog.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class BlogRemoveController {
     private final RemoveBlogUseCase removeBlogUseCase;
 
     @Operation(summary = "[A] 블로그 포스트 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{blogId}")
     public ApiResponse<Long> removeBlog(
             @PathVariable(name = "blogId") Long blogId

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogUpdateController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class BlogUpdateController {
     private final UpdateBlogUseCase updateBlogUseCase;
 
     @Operation(summary = "[A] 블로그 포스트 수정", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{blogId}")
     public ApiResponse<Long> updateBlog(
             @PathVariable(name = "blogId") Long blogId,

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +32,7 @@ public class BlogsRetrievalController {
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 작성자명 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BlogResponseDto>> retrieveBlogs(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/BlogsRetrievalController.java
@@ -28,11 +28,11 @@ public class BlogsRetrievalController {
     private final RetrieveBlogsUseCase retrieveBlogsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 블로그 포스트 조회(제목, 작성자명 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 블로그 포스트 조회(제목, 작성자명 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "2개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "제목, 작성자명 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<BlogResponseDto>> retrieveBlogs(
             @RequestParam(name = "title", required = false) String title,

--- a/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/DeletedBlogsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/blog/adapter/in/web/DeletedBlogsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedBlogsRetrievalController {
 
     private final RetrieveDeletedBlogsUseCase retrieveDeletedBlogsUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 블로그 포스트 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<BlogDetailsResponseDto>> retrieveDeletedBlogs(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DeletedDonationsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DeletedDonationsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedDonationsRetrievalController {
 
     private final RetrieveDeletedDonationsUseCase retrieveDeletedDonationsUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 후원 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<DonationResponseDto>> retrieveDeletedDonations(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class DonationRegisterController {
     private final RegisterDonationUseCase registerDonationUseCase;
 
     @Operation(summary = "[S] 후원 생성", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PostMapping("")
     public ApiResponse<Long> registerDonation(
             @Valid @RequestBody DonationRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.donation.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class DonationRemoveController {
     private final RemoveDonationUseCase removeDonationUseCase;
 
     @Operation(summary = "[S] 후원 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/{donationId}")
     public ApiResponse<Long> removeDonation(
             @PathVariable(name = "donationId") Long donationId

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationUpdateController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class DonationUpdateController {
     private final UpdateDonationUseCase updateDonationUseCase;
 
     @Operation(summary = "[S] 후원 정보 수정", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PatchMapping("/{donationId}")
     public ApiResponse<Long> updateDonation(
             @PathVariable(name = "donationId") Long donationId,

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationsByConditionsRetrievalController.java
@@ -29,11 +29,11 @@ public class DonationsByConditionsRetrievalController {
     private final RetrieveDonationsByConditionsUseCase retrieveDonationsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 후원 목록 조회(멤버 ID, 멤버 이름, 기간 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 후원 목록 조회(멤버 ID, 멤버 이름, 기간 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "멤버 ID, 멤버 이름, 기간 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<DonationResponseDto>> retrieveDonationsByConditions(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/DonationsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +33,7 @@ public class DonationsByConditionsRetrievalController {
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "멤버 ID, 멤버 이름, 기간 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<DonationResponseDto>> retrieveDonationsByConditions(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/MyDonationsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/MyDonationsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,7 +30,7 @@ public class MyDonationsRetrievalController {
 
     @Operation(summary = "[U] 나의 후원 정보", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/my-donations")
     public ApiResponse<PagedResponseDto<DonationResponseDto>> retrieveMyDonations(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/MyDonationsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/donation/adapter/in/web/MyDonationsRetrievalController.java
@@ -28,9 +28,9 @@ public class MyDonationsRetrievalController {
     private final RetrieveMyDonationsUseCase retrieveMyDonationsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 나의 후원 정보", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 나의 후원 정보", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my-donations")
     public ApiResponse<PagedResponseDto<DonationResponseDto>> retrieveMyDonations(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/DeletedMembershipFeesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/DeletedMembershipFeesRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +23,9 @@ public class DeletedMembershipFeesRetrievalController {
 
     private final RetrieveDeletedMembershipFeesUseCase retrieveDeletedMembershipFeesUseCase;
 
-    @GetMapping("/deleted")
-    @Secured({ "ROLE_SUPER" })
     @Operation(summary = "[S] 삭제된 회비 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<MembershipFeeResponseDto>> retrieveDeletedMembershipFees(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class MembershipFeeRegisterController {
     private final RegisterMembershipFeeUseCase registerMembershipFeeUseCase;
 
     @Operation(summary = "[U] 회비 신청", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> registerMembershipFee(
             @Valid @RequestBody MembershipFeeRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.membershipFee.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class MembershipFeeRemoveController {
     private final RemoveMembershipFeeUseCase removeMembershipFeeUseCase;
 
     @Operation(summary = "[S] 회비 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/{membershipFeeId}")
     public ApiResponse<Long> removeMembershipFee(
             @PathVariable(name = "membershipFeeId") Long membershipFeeId

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeUpdateController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public class MembershipFeeUpdateController {
     private final UpdateMembershipFeeUseCase updateMembershipFeeUseCase;
 
     @Operation(summary = "[S] 회비 정보 수정", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PatchMapping("/{membershipFeeId}")
     public ApiResponse<Long> updateMembershipFee(
             @PathVariable(name = "membershipFeeId") Long membershipFeeId,

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeesByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeesByConditionsRetrievalController.java
@@ -29,12 +29,12 @@ public class MembershipFeesByConditionsRetrievalController {
     private final RetrieveMembershipFeesByConditionsUseCase retrieveMembershipFeesByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 회비 정보 조회(멤버 ID, 멤버 이름, 카테고리, 상태 기준)", description = "ROLE_USER 이상의 권한이 필요함<br> " +
+    @Operation(summary = "[G] 회비 정보 조회(멤버 ID, 멤버 이름, 카테고리, 상태 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br> " +
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "멤버 ID, 멤버 이름, 카테고리 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "계좌 정보는 관리자 이상의 권한만 조회 가능<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<MembershipFeeResponseDto>> retrieveMembershipFeesByConditions(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeesByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeesByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,7 +34,7 @@ public class MembershipFeesByConditionsRetrievalController {
             "멤버 ID, 멤버 이름, 카테고리 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "계좌 정보는 관리자 이상의 권한만 조회 가능<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<MembershipFeeResponseDto>> retrieveMembershipFeesByConditions(
             @RequestParam(name = "memberId", required = false) String memberId,

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/DeletedProductsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/DeletedProductsRetrievalController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,7 +24,7 @@ public class DeletedProductsRetrievalController {
     private final RetrieveDeletedProductsUseCase retrieveDeletedProductsUseCase;
 
     @Operation(summary = "[S] 삭제된 서비스 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("/deleted")
     public ApiResponse<PagedResponseDto<ProductResponseDto>> retrieveDeletedProducts(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class ProductRegisterController {
     private final RegisterProductUseCase registerProductUseCase;
 
     @Operation(summary = "[A] 서비스 등록", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<Long> registerProduct(
             @Valid @RequestBody ProductRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.product.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +20,7 @@ public class ProductRemoveController {
     private final RemoveProductUseCase removeProductUseCase;
 
     @Operation(summary = "[A] 서비스 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("")
     public ApiResponse<Long> removeProduct(
             @RequestParam Long productId

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductUpdateController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductUpdateController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +23,7 @@ public class ProductUpdateController {
     private final UpdateProductUseCase updateProductUseCase;
 
     @Operation(summary = "[A] 서비스 수정", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{productId}")
     public ApiResponse<Long> updateProduct(
             @PathVariable(name = "productId") Long productId,

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductsByConditionsRetrievalController.java
@@ -28,10 +28,10 @@ public class ProductsByConditionsRetrievalController {
     private final RetrieveProductsByConditionsUseCase retrieveProductsByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 서비스 조회", description = "ROLE_USER 이상의 권한이 필요함<br> " +
+    @Operation(summary = "[G] 서비스 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br> " +
             "서비스명을 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ProductResponseDto>> retrieveProductsByConditions(
             @RequestParam(required = false) String productName,

--- a/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductsByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/product/adapter/in/web/ProductsByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +31,7 @@ public class ProductsByConditionsRetrievalController {
     @Operation(summary = "[U] 서비스 조회", description = "ROLE_USER 이상의 권한이 필요함<br> " +
             "서비스명을 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ProductResponseDto>> retrieveProductsByConditions(
             @RequestParam(required = false) String productName,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ActivitySchedulesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ActivitySchedulesRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +31,7 @@ public class ActivitySchedulesRetrievalController {
 
     @Operation(summary = "[U] 내 활동 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/activity")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveActivitySchedules(
             @RequestParam(name = "startDate") LocalDate startDate,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ActivitySchedulesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ActivitySchedulesRetrievalController.java
@@ -29,9 +29,9 @@ public class ActivitySchedulesRetrievalController {
     private final RetrieveActivitySchedulesUseCase retrieveActivitySchedulesUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 내 활동 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 내 활동 일정 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/activity")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveActivitySchedules(
             @RequestParam(name = "startDate") LocalDate startDate,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/CollectSchedulesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/CollectSchedulesRetrievalController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.schedule.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +20,7 @@ public class CollectSchedulesRetrievalController {
     private final RetrieveCollectSchedulesUseCase retrieveCollectSchedulesUseCase;
 
     @Operation(summary = "[U] 일정 모아보기", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/collect")
     public ApiResponse<ScheduleCollectResponseDto> retrieveCollectSchedules() {
         ScheduleCollectResponseDto schedules = retrieveCollectSchedulesUseCase.retrieveCollectSchedules();

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/CollectSchedulesRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/CollectSchedulesRetrievalController.java
@@ -19,8 +19,8 @@ public class CollectSchedulesRetrievalController {
 
     private final RetrieveCollectSchedulesUseCase retrieveCollectSchedulesUseCase;
 
-    @Operation(summary = "[U] 일정 모아보기", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "[G] 일정 모아보기", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/collect")
     public ApiResponse<ScheduleCollectResponseDto> retrieveCollectSchedules() {
         ScheduleCollectResponseDto schedules = retrieveCollectSchedulesUseCase.retrieveCollectSchedules();

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ScheduleRegisterController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ScheduleRegisterController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +23,7 @@ public class ScheduleRegisterController {
     private final RegisterScheduleUseCase registerScheduleUseCase;
 
     @Operation(summary = "[U] 일정 등록", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("")
     public ApiResponse<Long> registerSchedule(
             @Valid @RequestBody ScheduleRequestDto requestDto

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ScheduleRemoveController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/ScheduleRemoveController.java
@@ -3,7 +3,7 @@ package page.clab.api.domain.members.schedule.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +21,7 @@ public class ScheduleRemoveController {
     private final RemoveScheduleUseCase removeScheduleUseCase;
 
     @Operation(summary = "[U] 일정 삭제", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{scheduleId}")
     public ApiResponse<Long> removeSchedule(
             @PathVariable(name = "scheduleId") Long scheduleId

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesByConditionsRetrievalController.java
@@ -29,11 +29,11 @@ public class SchedulesByConditionsRetrievalController {
     private final RetrieveSchedulesByConditionsUseCase retrieveSchedulesByConditionsUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 일정 조회(연도, 월, 중요도 기준)", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 일정 조회(연도, 월, 중요도 기준)", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "연도, 월, 중요도 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveSchedulesByConditions(
             @RequestParam(name = "year", required = false) Integer year,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesByConditionsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesByConditionsRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +33,7 @@ public class SchedulesByConditionsRetrievalController {
             "3개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
             "연도, 월, 중요도 중 하나라도 입력하지 않으면 전체 조회됨<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/conditions")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveSchedulesByConditions(
             @RequestParam(name = "year", required = false) Integer year,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesWithinDateRangeRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesWithinDateRangeRetrievalController.java
@@ -29,9 +29,9 @@ public class SchedulesWithinDateRangeRetrievalController {
     private final RetrieveSchedulesWithinDateRangeUseCase retrieveSchedulesWithinDateRangeUseCase;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[G] 일정 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveSchedulesWithinDateRange(
             @RequestParam(name = "startDate") LocalDate startDate,

--- a/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesWithinDateRangeRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/adapter/in/web/SchedulesWithinDateRangeRetrievalController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +31,7 @@ public class SchedulesWithinDateRangeRetrievalController {
 
     @Operation(summary = "[U] 일정 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("")
     public ApiResponse<PagedResponseDto<ScheduleResponseDto>> retrieveSchedulesWithinDateRange(
             @RequestParam(name = "startDate") LocalDate startDate,

--- a/src/main/java/page/clab/api/external/memberManagement/member/application/port/ExternalRetrieveMemberUseCase.java
+++ b/src/main/java/page/clab/api/external/memberManagement/member/application/port/ExternalRetrieveMemberUseCase.java
@@ -48,6 +48,8 @@ public interface ExternalRetrieveMemberUseCase {
 
     MemberLoginInfoDto getMemberLoginInfoById(String memberId);
 
+    MemberLoginInfoDto getGuestMemberLoginInfo();
+
     MemberPositionInfoDto getCurrentMemberPositionInfo();
 
     MemberReviewInfoDto getMemberReviewInfoById(String memberId);

--- a/src/main/java/page/clab/api/external/memberManagement/member/application/service/ExternalMemberRetrievalService.java
+++ b/src/main/java/page/clab/api/external/memberManagement/member/application/service/ExternalMemberRetrievalService.java
@@ -13,6 +13,7 @@ import page.clab.api.domain.memberManagement.member.application.dto.shared.Membe
 import page.clab.api.domain.memberManagement.member.application.port.out.CheckMemberExistencePort;
 import page.clab.api.domain.memberManagement.member.application.port.out.RetrieveMemberPort;
 import page.clab.api.domain.memberManagement.member.domain.Member;
+import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.auth.util.AuthUtil;
 import page.clab.api.global.exception.NotFoundException;
@@ -154,6 +155,13 @@ public class ExternalMemberRetrievalService implements ExternalRetrieveMemberUse
     public MemberLoginInfoDto getMemberLoginInfoById(String memberId) {
         Member member = retrieveMemberPort.findByIdOrThrow(memberId);
         return MemberLoginInfoDto.create(member);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public MemberLoginInfoDto getGuestMemberLoginInfo() {
+        Member guestMember = retrieveMemberPort.findFirstByRoleOrThrow(Role.GUEST);
+        return MemberLoginInfoDto.create(guestMember);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
@@ -50,7 +50,7 @@ public class JwtTokenProvider {
         Date accessTokenExpiry = new Date(expiry.getTime() + (accessTokenDuration));
         String accessToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role.getKey())
+                .claim("role", role)
                 .issuedAt(expiry)
                 .expiration(accessTokenExpiry)
                 .signWith(key)
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
         Date refreshTokenExpiry = new Date(expiry.getTime() + (refreshTokenDuration));
         String refreshToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role.getKey())
+                .claim("role", role)
                 .issuedAt(expiry)
                 .expiration(refreshTokenExpiry)
                 .signWith(key)
@@ -92,6 +92,7 @@ public class JwtTokenProvider {
 
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get("role").toString().split(","))
+                        .map(r -> Role.valueOf(r).getKey())
                         .map(SimpleGrantedAuthority::new)
                         .toList();
 

--- a/src/main/java/page/clab/api/global/common/file/api/FileController.java
+++ b/src/main/java/page/clab/api/global/common/file/api/FileController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,7 +32,7 @@ public class FileController {
     private final FileService fileService;
 
     @Operation(summary = "[U] 게시글 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/boards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> boardUpload(
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
@@ -43,7 +43,7 @@ public class FileController {
     }
 
     @Operation(summary = "[U] 멤버 프로필 사진 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<UploadedFileResponseDto> profileUpload(
             @RequestParam(name = "multipartFile") MultipartFile multipartFile,
@@ -53,8 +53,8 @@ public class FileController {
         return ApiResponse.success(responseDto);
     }
 
-    @Operation(summary = "[U] 함께하는 활동 사진 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_ADMIN", "ROLE_SUPER" })
+    @Operation(summary = "[A] 함께하는 활동 사진 업로드", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping(value = "/activity-photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> activityUpload(
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
@@ -65,7 +65,7 @@ public class FileController {
     }
 
     @Operation(summary = "[U] 멤버 클라우드 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/members", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> memberCloudUpload(
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
@@ -76,7 +76,7 @@ public class FileController {
     }
 
     @Operation(summary = "[U] 활동 그룹 과제 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/assignment/{activityGroupId}/{activityGroupBoardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> assignmentUpload(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
@@ -89,7 +89,7 @@ public class FileController {
     }
 
     @Operation(summary = "[U] 회비 증빙 사진 업로드", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/membership-fee", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> assignmentUpload(
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
@@ -101,7 +101,7 @@ public class FileController {
 
     @Operation(summary = "[U] 파일 삭제", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "본인 외의 정보는 ROLE_SUPER만 가능<br>" + "/resources/files/~를 입력. 즉 생성시 전달받은 url을 입력.")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("")
     public ApiResponse<String> deleteFile(@RequestBody DeleteFileRequestDto deleteFileRequestDto)
             throws PermissionDeniedException {

--- a/src/main/java/page/clab/api/global/common/slack/api/NotificationSettingController.java
+++ b/src/main/java/page/clab/api/global/common/slack/api/NotificationSettingController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +26,7 @@ public class NotificationSettingController {
     private final NotificationSettingService notificationSettingService;
 
     @Operation(summary = "[S] 슬랙 알림 조회", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @GetMapping("")
     public ApiResponse<List<NotificationSettingResponseDto>> getNotificationSettings() {
         List<NotificationSettingResponseDto> notificationSettings = notificationSettingService.getNotificationSettings();
@@ -34,7 +34,7 @@ public class NotificationSettingController {
     }
 
     @Operation(summary = "[S] 슬랙 알림 설정 변경", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @Secured({ "ROLE_SUPER" })
+    @PreAuthorize("hasRole('SUPER')")
     @PutMapping("")
     public ApiResponse<Void> updateNotificationSetting(
             @Valid @RequestBody NotificationSettingUpdateRequestDto requestDto

--- a/src/main/java/page/clab/api/global/config/RoleHierarchyConfig.java
+++ b/src/main/java/page/clab/api/global/config/RoleHierarchyConfig.java
@@ -1,0 +1,19 @@
+package page.clab.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+
+@Configuration
+public class RoleHierarchyConfig {
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy("""
+                ROLE_SUPER > ROLE_ADMIN
+                ROLE_ADMIN > ROLE_USER
+                ROLE_USER > ROLE_GUEST
+                """);
+    }
+}

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
-import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -43,7 +42,7 @@ import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(securedEnabled = true)
+@EnableMethodSecurity
 @RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {


### PR DESCRIPTION
## Summary

> #454 

Spring Security 기반의 인증/인가 시스템을 개선하여 보안 정책을 강화하고, 사용자 경험을 개선하기 위한 작업을 진행했습니다. 이 PR에서는 네트워크 환경 변화에 따른 정책을 개편하고, GUEST 로그인 기능을 도입하였습니다. SUPER, ADMIN, USER 권한 체계에 GUEST 권한을 추가하여 보다 유연한 권한 관리를 구현했습니다.

## Tasks

1. **Spring Security 설정 변경**
    - `RoleHierarchy` 설정을 통해 GUEST 권한을 SUPER, ADMIN, USER 아래에 배치.
    - GUEST 로그인 시, GUEST 권한을 가진 JWT 토큰을 발급하도록 설정.

2. **네트워크 감지 정책 개편**
    - ADMIN 이상 권한의 사용자의 네트워크 변경 시, IP가 다를 경우 기존 JWT 토큰을 삭제하도록 기존 로직을 유지.
    - USER 권한 이하의 사용자는 네트워크 변경에 관계없이 중복 로그인을 허용하도록 설정.

3. **GUEST 계정 생성 및 자동 로그인 구현**
    - 단일 GUEST 계정을 생성하고, GUEST로 로그인 버튼을 눌렀을 때 해당 계정으로 자동 로그인되도록 구현.
    - 게스트 로그인 API 추가 및 해당 API 호출 시 GUEST 권한의 JWT 토큰을 반환하도록 설정.

4. **Spring Security 마이그레이션**
    - Deprecated된 메소드들을 최신 메소드로 마이그레이션.

## Reference

- [Method Security](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html)
- [Authorize HttpServletRequests](https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html)