### PR TITLE
회비 정보 수정 권한 ADMIN으로 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeUpdateController.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/adapter/in/web/MembershipFeeUpdateController.java
@@ -23,8 +23,8 @@ public class MembershipFeeUpdateController {
 
     private final UpdateMembershipFeeUseCase updateMembershipFeeUseCase;
 
-    @Operation(summary = "[S] 회비 정보 수정", description = "ROLE_SUPER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('SUPER')")
+    @Operation(summary = "[A] 회비 정보 수정", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{membershipFeeId}")
     public ApiResponse<Long> updateMembershipFee(
             @PathVariable(name = "membershipFeeId") Long membershipFeeId,


### PR DESCRIPTION
## Summary

> #461 
기존에는 SUPER 권한을 가진 사용자만 회비 정보를 수정하고 승인할 수 있었기에,
ADMIN 권한을 가진 운영진의 회비 승인 처리가 불가능했습니다. 이에 SUPER -> ADMIN으로 권한을 수정하고자 합니다.

## Tasks

-  회비 정보 수정 권한 ADMIN으로 수정

## ETC

main 까지 머지가 되어야 해당 수정이 실서비스에 적용될 것 같은데 develop -> main PR을 하나 올려야 될까요?