### PR TITLE
운영진 슬랙 알림 기능 추가 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardRegisterService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardRegisterService.java
@@ -7,7 +7,7 @@ import page.clab.api.domain.community.board.application.dto.request.BoardRequest
 import page.clab.api.domain.community.board.application.port.in.RegisterBoardUseCase;
 import page.clab.api.domain.community.board.application.port.out.RegisterBoardPort;
 import page.clab.api.domain.community.board.domain.Board;
-import page.clab.api.domain.community.board.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackBoardInfo;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.external.memberManagement.notification.application.port.ExternalSendNotificationUseCase;

--- a/src/main/java/page/clab/api/domain/members/membershipFee/application/service/MembershipFeeRegisterService.java
+++ b/src/main/java/page/clab/api/domain/members/membershipFee/application/service/MembershipFeeRegisterService.java
@@ -3,12 +3,15 @@ package page.clab.api.domain.members.membershipFee.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
 import page.clab.api.domain.members.membershipFee.application.dto.request.MembershipFeeRequestDto;
 import page.clab.api.domain.members.membershipFee.application.port.in.RegisterMembershipFeeUseCase;
 import page.clab.api.domain.members.membershipFee.application.port.out.RegisterMembershipFeePort;
 import page.clab.api.domain.members.membershipFee.domain.MembershipFee;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.external.memberManagement.notification.application.port.ExternalSendNotificationUseCase;
+import page.clab.api.global.common.slack.application.SlackService;
+import page.clab.api.global.common.slack.domain.SlackMembershipFeeInfo;
 
 @Service
 @RequiredArgsConstructor
@@ -17,13 +20,16 @@ public class MembershipFeeRegisterService implements RegisterMembershipFeeUseCas
     private final RegisterMembershipFeePort registerMembershipFeePort;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
     private final ExternalSendNotificationUseCase externalSendNotificationUseCase;
+    private final SlackService slackService;
 
     @Transactional
     @Override
     public Long registerMembershipFee(MembershipFeeRequestDto requestDto) {
-        String currentMemberId = externalRetrieveMemberUseCase.getCurrentMemberId();
-        MembershipFee membershipFee = MembershipFeeRequestDto.toEntity(requestDto, currentMemberId);
+        MemberBasicInfoDto memberInfo = externalRetrieveMemberUseCase.getCurrentMemberBasicInfo();
+        MembershipFee membershipFee = MembershipFeeRequestDto.toEntity(requestDto, memberInfo.getMemberId());
         externalSendNotificationUseCase.sendNotificationToAdmins("새로운 회비 내역이 등록되었습니다.");
+        SlackMembershipFeeInfo membershipFeeInfo = SlackMembershipFeeInfo.create(membershipFee, memberInfo);
+        slackService.sendNewMembershipFeeNotification(membershipFeeInfo);
         return registerMembershipFeePort.save(membershipFee).getId();
     }
 }

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import page.clab.api.domain.community.board.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
+import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.common.slack.event.NotificationEvent;
@@ -34,11 +35,15 @@ public class SlackService {
     }
 
     public void sendNewApplicationNotification(ApplicationRequestDto applicationRequestDto) {
-        eventPublisher.publishEvent(new NotificationEvent(this, GeneralAlertType.APPLICATION_CREATED, null, applicationRequestDto));
+        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_APPLICATION, null, applicationRequestDto));
     }
 
     public void sendNewBoardNotification(SlackBoardInfo board) {
-        eventPublisher.publishEvent(new NotificationEvent(this, GeneralAlertType.BOARD_CREATED, null, board));
+        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_BOARD, null, board));
+    }
+
+    public void sendNewMembershipFeeNotification() {
+        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, null));
     }
 
     @EventListener(ContextRefreshedEvent.class)

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -5,7 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import page.clab.api.domain.community.board.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
 import page.clab.api.global.common.slack.domain.ExecutivesAlertType;

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -1,8 +1,6 @@
 package page.clab.api.global.common.slack.application;
 
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
@@ -14,40 +12,47 @@ import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.common.slack.event.NotificationEvent;
+import page.clab.api.global.config.SlackConfig;
 
 @Service
-@RequiredArgsConstructor
-@Slf4j
 public class SlackService {
 
     private final ApplicationEventPublisher eventPublisher;
+    private final String coreTeamWebhookUrl;
+    private final String executivesWebhookUrl;
+
+    public SlackService(ApplicationEventPublisher eventPublisher, SlackConfig slackConfig) {
+        this.eventPublisher = eventPublisher;
+        this.coreTeamWebhookUrl = slackConfig.getCoreTeamWebhookUrl();
+        this.executivesWebhookUrl = slackConfig.getExecutivesWebhookUrl();
+    }
 
     public void sendServerErrorNotification(HttpServletRequest request, Exception e) {
-        eventPublisher.publishEvent(new NotificationEvent(this, GeneralAlertType.SERVER_ERROR, request, e));
+        eventPublisher.publishEvent(new NotificationEvent(this, coreTeamWebhookUrl, GeneralAlertType.SERVER_ERROR, request, e));
     }
 
     public void sendSecurityAlertNotification(HttpServletRequest request, SecurityAlertType alertType, String additionalMessage) {
-        eventPublisher.publishEvent(new NotificationEvent(this, alertType, request, additionalMessage));
+        eventPublisher.publishEvent(new NotificationEvent(this, coreTeamWebhookUrl, alertType, request, additionalMessage));
     }
 
     public void sendAdminLoginNotification(HttpServletRequest request, MemberLoginInfoDto loginMember) {
-        eventPublisher.publishEvent(new NotificationEvent(this, GeneralAlertType.ADMIN_LOGIN, request, loginMember));
+        eventPublisher.publishEvent(new NotificationEvent(this, coreTeamWebhookUrl, GeneralAlertType.ADMIN_LOGIN, request, loginMember));
     }
 
     public void sendNewApplicationNotification(ApplicationRequestDto applicationRequestDto) {
-        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_APPLICATION, null, applicationRequestDto));
+        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_APPLICATION, null, applicationRequestDto));
     }
 
     public void sendNewBoardNotification(SlackBoardInfo board) {
-        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_BOARD, null, board));
+        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_BOARD, null, board));
     }
 
     public void sendNewMembershipFeeNotification() {
-        eventPublisher.publishEvent(new NotificationEvent(this, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, null));
+        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, null));
     }
 
     @EventListener(ContextRefreshedEvent.class)
     public void sendServerStartNotification() {
-        eventPublisher.publishEvent(new NotificationEvent(this, GeneralAlertType.SERVER_START, null, null));
+        eventPublisher.publishEvent(new NotificationEvent(this, coreTeamWebhookUrl, GeneralAlertType.SERVER_START, null, null));
     }
 }

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -5,12 +5,13 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import page.clab.api.global.common.slack.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
 import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
+import page.clab.api.global.common.slack.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackMembershipFeeInfo;
 import page.clab.api.global.common.slack.event.NotificationEvent;
 import page.clab.api.global.config.SlackConfig;
 
@@ -47,8 +48,8 @@ public class SlackService {
         eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_BOARD, null, board));
     }
 
-    public void sendNewMembershipFeeNotification() {
-        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, null));
+    public void sendNewMembershipFeeNotification(SlackMembershipFeeInfo membershipFee) {
+        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, membershipFee));
     }
 
     @EventListener(ContextRefreshedEvent.class)

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -20,7 +20,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import page.clab.api.domain.community.board.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
 import page.clab.api.global.common.slack.domain.AlertType;

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -24,6 +24,7 @@ import page.clab.api.domain.community.board.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
 import page.clab.api.global.common.slack.domain.AlertType;
+import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.config.SlackConfig;
@@ -48,6 +49,7 @@ public class SlackServiceHelper {
 
     private final Slack slack;
     private final String coreTeamWebhookUrl;
+    private final String exeutivesWebhookUrl;
     private final String webUrl;
     private final String apiUrl;
     private final String color;
@@ -57,6 +59,7 @@ public class SlackServiceHelper {
     public SlackServiceHelper(SlackConfig slackConfig, Environment environment, AttributeStrategy attributeStrategy) {
         this.slack = slackConfig.slack();
         this.coreTeamWebhookUrl = slackConfig.getCoreTeamWebhookUrl();
+        this.exeutivesWebhookUrl = slackConfig.getExecutivesWebhookUrl();
         this.webUrl = slackConfig.getWebUrl();
         this.apiUrl = slackConfig.getApiUrl();
         this.color = slackConfig.getColor();
@@ -106,21 +109,27 @@ public class SlackServiceHelper {
                         return createAdminLoginBlocks(request, (MemberLoginInfoDto) additionalData);
                     }
                     break;
-                case APPLICATION_CREATED:
-                    if (additionalData instanceof ApplicationRequestDto) {
-                        return createApplicationBlocks((ApplicationRequestDto) additionalData);
-                    }
-                    break;
-                case BOARD_CREATED:
-                    if (additionalData instanceof SlackBoardInfo) {
-                        return createBoardBlocks((SlackBoardInfo) additionalData);
-                    }
-                    break;
                 case SERVER_START:
                     return createServerStartBlocks();
                 case SERVER_ERROR:
                     if (additionalData instanceof Exception) {
                         return createErrorBlocks(request, (Exception) additionalData);
+                    }
+                    break;
+                default:
+                    log.error("Unknown alert type: {}", alertType);
+                    return List.of();
+            }
+        } else if (alertType instanceof ExecutivesAlertType) {
+            switch ((ExecutivesAlertType) alertType) {
+                case NEW_APPLICATION:
+                    if (additionalData instanceof ApplicationRequestDto) {
+                        return createApplicationBlocks((ApplicationRequestDto) additionalData);
+                    }
+                    break;
+                case NEW_BOARD:
+                    if (additionalData instanceof SlackBoardInfo) {
+                        return createBoardBlocks((SlackBoardInfo) additionalData);
                     }
                     break;
                 default:

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 public class SlackServiceHelper {
 
     private final Slack slack;
-    private final String webhookUrl;
+    private final String coreTeamWebhookUrl;
     private final String webUrl;
     private final String apiUrl;
     private final String color;
@@ -56,7 +56,7 @@ public class SlackServiceHelper {
 
     public SlackServiceHelper(SlackConfig slackConfig, Environment environment, AttributeStrategy attributeStrategy) {
         this.slack = slackConfig.slack();
-        this.webhookUrl = slackConfig.getWebhookUrl();
+        this.coreTeamWebhookUrl = slackConfig.getCoreTeamWebhookUrl();
         this.webUrl = slackConfig.getWebUrl();
         this.apiUrl = slackConfig.getApiUrl();
         this.color = slackConfig.getColor();
@@ -82,7 +82,7 @@ public class SlackServiceHelper {
                                     .build()
                     )).build();
             try {
-                WebhookResponse response = slack.send(webhookUrl, payload);
+                WebhookResponse response = slack.send(coreTeamWebhookUrl, payload);
                 if (response.getCode() == 200) {
                     return true;
                 } else {

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -48,8 +48,6 @@ import java.util.stream.Collectors;
 public class SlackServiceHelper {
 
     private final Slack slack;
-    private final String coreTeamWebhookUrl;
-    private final String exeutivesWebhookUrl;
     private final String webUrl;
     private final String apiUrl;
     private final String color;
@@ -58,8 +56,6 @@ public class SlackServiceHelper {
 
     public SlackServiceHelper(SlackConfig slackConfig, Environment environment, AttributeStrategy attributeStrategy) {
         this.slack = slackConfig.slack();
-        this.coreTeamWebhookUrl = slackConfig.getCoreTeamWebhookUrl();
-        this.exeutivesWebhookUrl = slackConfig.getExecutivesWebhookUrl();
         this.webUrl = slackConfig.getWebUrl();
         this.apiUrl = slackConfig.getApiUrl();
         this.color = slackConfig.getColor();
@@ -72,9 +68,8 @@ public class SlackServiceHelper {
         return (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
     }
 
-    public CompletableFuture<Boolean> sendSlackMessage(AlertType alertType, HttpServletRequest request, Object additionalData) {
+    public CompletableFuture<Boolean> sendSlackMessage(String webhookUrl, AlertType alertType, HttpServletRequest request, Object additionalData) {
         List<LayoutBlock> blocks = createBlocks(alertType, request, additionalData);
-
         return CompletableFuture.supplyAsync(() -> {
             Payload payload = Payload.builder()
                     .blocks(List.of(blocks.getFirst()))
@@ -85,7 +80,7 @@ public class SlackServiceHelper {
                                     .build()
                     )).build();
             try {
-                WebhookResponse response = slack.send(coreTeamWebhookUrl, payload);
+                WebhookResponse response = slack.send(webhookUrl, payload);
                 if (response.getCode() == 200) {
                     return true;
                 } else {

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -20,13 +20,14 @@ import org.springframework.core.env.Environment;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import page.clab.api.global.common.slack.domain.SlackBoardInfo;
 import page.clab.api.domain.hiring.application.application.dto.request.ApplicationRequestDto;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberLoginInfoDto;
 import page.clab.api.global.common.slack.domain.AlertType;
 import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
+import page.clab.api.global.common.slack.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackMembershipFeeInfo;
 import page.clab.api.global.config.SlackConfig;
 import page.clab.api.global.util.HttpReqResUtil;
 
@@ -127,6 +128,10 @@ public class SlackServiceHelper {
                         return createBoardBlocks((SlackBoardInfo) additionalData);
                     }
                     break;
+                case NEW_MEMBERSHIP_FEE:
+                    if (additionalData instanceof SlackMembershipFeeInfo) {
+                        return createMembershipFeeBlocks((SlackMembershipFeeInfo) additionalData);
+                    }
                 default:
                     log.error("Unknown alert type: {}", alertType);
                     return List.of();
@@ -218,6 +223,20 @@ public class SlackServiceHelper {
                 markdownText("*User:*\n" + board.getUsername())
         ))));
         return blocks;
+    }
+
+    private List<LayoutBlock> createMembershipFeeBlocks(SlackMembershipFeeInfo additionalData) {
+        String username = additionalData.getMemberId() + " " + additionalData.getMemberName();
+
+        return Arrays.asList(
+                section(section -> section.text(markdownText(":dollar: *New Membership Fee*"))),
+                section(section -> section.fields(Arrays.asList(
+                        markdownText("*User:*\n" + username),
+                        markdownText("*Category:*\n" + additionalData.getCategory()),
+                        markdownText("*Amount:*\n" + additionalData.getAmount() + "원")
+                ))),
+                section(section -> section.text(markdownText("*Content:*\n" + additionalData.getContent())))
+        );
     }
 
     private List<LayoutBlock> createServerStartBlocks() {

--- a/src/main/java/page/clab/api/global/common/slack/domain/AlertTypeConverter.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/AlertTypeConverter.java
@@ -19,6 +19,9 @@ public class AlertTypeConverter implements AttributeConverter<AlertType, String>
         for (SecurityAlertType type : SecurityAlertType.values()) {
             CACHE.put(type.getTitle(), type);
         }
+        for (ExecutivesAlertType type : ExecutivesAlertType.values()) {
+            CACHE.put(type.getTitle(), type);
+        }
     }
 
     @Override

--- a/src/main/java/page/clab/api/global/common/slack/domain/ExecutivesAlertType.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/ExecutivesAlertType.java
@@ -1,0 +1,16 @@
+package page.clab.api.global.common.slack.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExecutivesAlertType implements AlertType {
+
+    NEW_APPLICATION("새 지원서", "New application has been submitted."),
+    NEW_BOARD("새 게시글", "New board has been posted."),
+    NEW_MEMBERSHIP_FEE("새 회비 신청", "New membership fee has been submitted.");
+
+    private final String title;
+    private final String defaultMessage;
+}

--- a/src/main/java/page/clab/api/global/common/slack/domain/GeneralAlertType.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/GeneralAlertType.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 public enum GeneralAlertType implements AlertType {
 
     ADMIN_LOGIN("관리자 로그인", "Admin login."),
-    APPLICATION_CREATED("새 지원서", "New application has been submitted."),
-    BOARD_CREATED("새 게시글", "New board has been created."),
     SERVER_START("서버 시작", "Server has been started."),
     SERVER_ERROR("서버 에러", "Server error occurred.");
 

--- a/src/main/java/page/clab/api/global/common/slack/domain/SlackBoardInfo.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/SlackBoardInfo.java
@@ -1,7 +1,8 @@
-package page.clab.api.domain.community.board.domain;
+package page.clab.api.global.common.slack.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
 
 @Getter

--- a/src/main/java/page/clab/api/global/common/slack/domain/SlackBoardInfo.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/SlackBoardInfo.java
@@ -10,9 +10,7 @@ import page.clab.api.domain.memberManagement.member.application.dto.shared.Membe
 public class SlackBoardInfo {
 
     private String title;
-
     private String category;
-
     private String username;
 
     public static SlackBoardInfo create(Board board, MemberDetailedInfoDto memberInfo) {

--- a/src/main/java/page/clab/api/global/common/slack/domain/SlackMembershipFeeInfo.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/SlackMembershipFeeInfo.java
@@ -1,0 +1,27 @@
+package page.clab.api.global.common.slack.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
+import page.clab.api.domain.members.membershipFee.domain.MembershipFee;
+
+@Getter
+@Builder
+public class SlackMembershipFeeInfo {
+
+    private String memberId;
+    private String memberName;
+    private String category;
+    private Long amount;
+    private String content;
+
+    public static SlackMembershipFeeInfo create(MembershipFee membershipFee, MemberBasicInfoDto memberInfo) {
+        return SlackMembershipFeeInfo.builder()
+                .memberId(memberInfo.getMemberId())
+                .memberName(memberInfo.getMemberName())
+                .category(membershipFee.getCategory())
+                .content(membershipFee.getContent())
+                .amount(membershipFee.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/page/clab/api/global/common/slack/event/NotificationEvent.java
+++ b/src/main/java/page/clab/api/global/common/slack/event/NotificationEvent.java
@@ -8,12 +8,14 @@ import page.clab.api.global.common.slack.domain.AlertType;
 @Getter
 public class NotificationEvent extends ApplicationEvent {
 
+    private final String webhookUrl;
     private final AlertType alertType;
     private final HttpServletRequest request;
     private final Object additionalData;
 
-    public NotificationEvent(Object source, AlertType alertType, HttpServletRequest request, Object additionalData) {
+    public NotificationEvent(Object source, String webhookUrl, AlertType alertType, HttpServletRequest request, Object additionalData) {
         super(source);
+        this.webhookUrl = webhookUrl;
         this.alertType = alertType;
         this.request = request;
         this.additionalData = additionalData;

--- a/src/main/java/page/clab/api/global/common/slack/listener/NotificationListener.java
+++ b/src/main/java/page/clab/api/global/common/slack/listener/NotificationListener.java
@@ -22,7 +22,7 @@ public class NotificationListener {
         NotificationSetting setting = settingService.getOrCreateDefaultSetting(alertType);
 
         if (setting.isEnabled()) {
-            slackServiceHelper.sendSlackMessage(alertType, event.getRequest(), event.getAdditionalData());
+            slackServiceHelper.sendSlackMessage(event.getWebhookUrl(), alertType, event.getRequest(), event.getAdditionalData());
         }
     }
 }

--- a/src/main/java/page/clab/api/global/config/SlackConfig.java
+++ b/src/main/java/page/clab/api/global/config/SlackConfig.java
@@ -13,7 +13,8 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "slack")
 public class SlackConfig {
 
-    private String webhookUrl;
+    private String coreTeamWebhookUrl;
+    private String executivesWebhookUrl;
     private String webUrl;
     private String apiUrl;
     private String color;


### PR DESCRIPTION
## Summary

> #464

운영진들이 회비 신청, 신규 게시글 작성, 동아리 신청 등의 내역을 실시간으로 확인하고 대응할 수 있도록, 관련 내역을 운영진 전용 슬랙 채널로 자동 알림을 보내는 기능을 추가하였습니다.

## Tasks

- 회비 신청 자동 알림
    - 회비 신청이 들어올 경우, 신청자의 상세 정보를 포함하여 운영진 전용 슬랙 채널로 자동으로 알림이 전송되도록 구현하였습니다.

- 신규 게시글 알림
    - 동아리 홈페이지에 신규 게시글이 작성될 때 운영진 전용 슬랙 채널로 자동 알림이 전송되도록 구현하였습니다.
    - 게시글의 제목과 작성자의 이름 등이 포함된 알림 내용 구성을 완료하였습니다.

- 동아리 신청 알림
    - 신규 동아리 신청이 있을 경우, 신청자의 기본 정보와 함께 운영진 전용 슬랙 채널로 알림이 전송되도록 구현하였습니다.

- 운영진 전용 슬랙 채널 설정
    - 운영진만 접근할 수 있는 슬랙 채널을 별도로 만들어, 모든 알림이 해당 채널로만 가도록 설정하였습니다.

- 알림 기능 테스트 및 피드백 반영
    - 슬랙 API를 활용하여 각 알림 기능이 제대로 동작하는지 테스트 진행하였고, 알림 내용 검토 후 피드백을 반영하여 개선 작업을 완료하였습니다.

## ETC

- 개인정보 보호
    - 슬랙 알림 시 개인정보 보호를 위해 계좌 정보 및 기타 민감한 정보는 포함하지 않도록 철저히 관리하였습니다.

- 알림 통합 관리
    - 다양한 알림이 운영진 전용 슬랙 채널로 일원화되므로, 혼란이 없도록 알림 내용과 형식을 통일하였습니다.