### PR TITLE
`@PreAuthorize`를 통한 API 권한 검사 시 403 상태코드 반환하도록 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -112,7 +112,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             AuthenticationInfoNotFoundException.class,
             UnAuthorizeException.class,
-            AccessDeniedException.class,
             LoginFailedException.class,
             MemberLockedException.class,
             BadCredentialsException.class,
@@ -128,6 +127,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
+            AccessDeniedException.class,
             PermissionDeniedException.class,
             InvalidBorrowerException.class,
     })


### PR DESCRIPTION
## Summary

> #468 

`@PreAuthorize`에서 발생하는 권한 부족 예외를 처리하여, 기존 401 상태 코드 대신 403 상태 코드를 반환하도록 리팩토링하였습니다. 이로써 인증된 사용자가 권한이 부족할 때 올바르게 403 상태 코드가 반환되도록 개선되었습니다.

## Tasks

- 기존의 예외 처리 로직에서 401 반환 부분을 403으로 변경

## ETC

- [HTTP 상태 코드](https://developer.mozilla.org/ko/docs/Web/HTTP/Status)
![image](https://github.com/user-attachments/assets/005a4b6e-c4d7-48de-a80a-89ea98173dae)
![image](https://github.com/user-attachments/assets/d05db48c-ac8c-4055-908a-3a662130253e)