### PR TITLE
feat: 활동 그룹 관련 API 응답 내용 수정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'page.clab'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 
 jar {
     enabled = false
@@ -15,23 +15,12 @@ bootJar {
     archivesBaseName = "clab"
     archiveFileName = "clab.jar"
     archiveVersion = "1.0.0"
-
-    if (project.hasProperty('prod')) {
-        archiveFileName = "clab-prod.jar"
-    } else if (project.hasProperty('stage')) {
-        archiveFileName = "clab-stage.jar"
-    } else {
-        archiveFileName = "clab.jar"
-    }
 }
-
-test {
-	systemProperty 'spring.profiles.active', findProperty('env') ?: 'dev'
-}
-
 
 java {
-    sourceCompatibility = '21'
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
@@ -106,10 +95,10 @@ dependencies {
 
     // Image
     implementation 'commons-io:commons-io:2.16.1'
-    implementation 'com.drewnoakes:metadata-extractor:2.14.0'
+    implementation 'com.drewnoakes:metadata-extractor:2.19.0'
     implementation 'org.imgscalr:imgscalr-lib:4.2'
 
-    //Emoji
+    // Emoji
     implementation 'com.ibm.icu:icu4j:75.1'
 
     // Test
@@ -121,13 +110,13 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-def querydslDir = "$buildDir/generated/querydsl"
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
 sourceSets {
     main.java.srcDirs += [ querydslDir ]
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.generatedSourceOutputDirectory = file(querydslDir)
 }
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -22,6 +22,7 @@ import page.clab.api.domain.activity.activitygroup.domain.GroupMemberStatus;
 import page.clab.api.domain.activity.activitygroup.dto.param.GroupScheduleDto;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupRequestDto;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupUpdateRequestDto;
+import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardStatusUpdatedResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupMemberWithApplyReasonResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupResponseDto;
 import page.clab.api.global.common.dto.ApiResponse;
@@ -66,12 +67,12 @@ public class ActivityGroupAdminController {
     @Operation(summary = "[A] 활동 상태 변경", description = "ROLE_ADMIN 이상의 권한이 필요함")
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("manage/{activityGroupId}")
-    public ApiResponse<Long> manageActivityGroupStatus(
+    public ApiResponse<ActivityGroupBoardStatusUpdatedResponseDto> manageActivityGroupStatus(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "activityGroupStatus") ActivityGroupStatus status
     ) {
-        Long id = activityGroupAdminService.manageActivityGroup(activityGroupId, status);
-        return ApiResponse.success(id);
+        ActivityGroupBoardStatusUpdatedResponseDto activityGroupBoardStatusUpdatedResponseDto = activityGroupAdminService.manageActivityGroup(activityGroupId, status);
+        return ApiResponse.success(activityGroupBoardStatusUpdatedResponseDto);
     }
 
     @Operation(summary = "[A] 활동 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
@@ -127,12 +128,12 @@ public class ActivityGroupAdminController {
     @Operation(summary = "[U] 신청 멤버 상태 변경", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("/accept")
-    public ApiResponse<String> acceptGroupMember(
+    public ApiResponse<Long> acceptGroupMember(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "memberId") String memberId,
             @RequestParam(name = "status") GroupMemberStatus status
     ) throws PermissionDeniedException {
-        String id = activityGroupAdminService.manageGroupMemberStatus(activityGroupId, memberId, status);
+        Long id = activityGroupAdminService.manageGroupMemberStatus(activityGroupId, memberId, status);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -71,8 +71,8 @@ public class ActivityGroupAdminController {
             @PathVariable(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "activityGroupStatus") ActivityGroupStatus status
     ) {
-        ActivityGroupBoardStatusUpdatedResponseDto activityGroupBoardStatusUpdatedResponseDto = activityGroupAdminService.manageActivityGroup(activityGroupId, status);
-        return ApiResponse.success(activityGroupBoardStatusUpdatedResponseDto);
+        ActivityGroupBoardStatusUpdatedResponseDto updatedStatusDto = activityGroupAdminService.manageActivityGroup(activityGroupId, status);
+        return ApiResponse.success(updatedStatusDto);
     }
 
     @Operation(summary = "[A] 활동 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
@@ -20,6 +20,7 @@ import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupBoardCate
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoardRequestDto;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoardUpdateRequestDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardChildResponseDto;
+import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardReferenceDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardUpdateResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.AssignmentSubmissionWithFeedbackResponseDto;
@@ -50,13 +51,13 @@ public class ActivityGroupBoardController {
     )
     @PreAuthorize("hasRole('USER')")
     @PostMapping("")
-    public ApiResponse<Long> createActivityGroupBoard(
+    public ApiResponse<ActivityGroupBoardReferenceDto> createActivityGroupBoard(
             @RequestParam(name = "parentId", required = false) Long parentId,
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @Valid @RequestBody ActivityGroupBoardRequestDto requestDto
     ) throws PermissionDeniedException {
-        Long id = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
-        return ApiResponse.success(id);
+        ActivityGroupBoardReferenceDto activityGroupBoard = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
+        return ApiResponse.success(activityGroupBoard);
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
@@ -127,22 +128,22 @@ public class ActivityGroupBoardController {
     @Operation(summary = "[U] 활동 그룹 게시판 수정", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("")
-    public ApiResponse<ActivityGroupBoardUpdateResponseDto> updateActivityGroupBoard(
+    public ApiResponse<ActivityGroupBoardReferenceDto> updateActivityGroupBoard(
             @RequestParam(name = "activityGroupBoardId") Long activityGroupBoardId,
             @Valid @RequestBody ActivityGroupBoardUpdateRequestDto requestDto
     ) throws PermissionDeniedException {
-        ActivityGroupBoardUpdateResponseDto board = activityGroupBoardService.updateActivityGroupBoard(activityGroupBoardId, requestDto);
-        return ApiResponse.success(board);
+        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.updateActivityGroupBoard(activityGroupBoardId, requestDto);
+        return ApiResponse.success(activityGroupBoardReferenceDto);
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 삭제", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @DeleteMapping("")
-    public ApiResponse<Long> deleteActivityGroupBoard(
+    public ApiResponse<ActivityGroupBoardReferenceDto> deleteActivityGroupBoard(
             @RequestParam Long activityGroupBoardId
     ) throws PermissionDeniedException {
-        Long id = activityGroupBoardService.deleteActivityGroupBoard(activityGroupBoardId);
-        return ApiResponse.success(id);
+        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.deleteActivityGroupBoard(activityGroupBoardId);
+        return ApiResponse.success(activityGroupBoardReferenceDto);
     }
 
     @Operation(summary = "[S] 삭제된 활동 그룹 게시판 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
@@ -56,8 +56,8 @@ public class ActivityGroupBoardController {
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @Valid @RequestBody ActivityGroupBoardRequestDto requestDto
     ) throws PermissionDeniedException {
-        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
-        return ApiResponse.success(activityGroupBoardReferenceDto);
+        ActivityGroupBoardReferenceDto referenceDto = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
+        return ApiResponse.success(referenceDto);
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
@@ -132,8 +132,8 @@ public class ActivityGroupBoardController {
             @RequestParam(name = "activityGroupBoardId") Long activityGroupBoardId,
             @Valid @RequestBody ActivityGroupBoardUpdateRequestDto requestDto
     ) throws PermissionDeniedException {
-        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.updateActivityGroupBoard(activityGroupBoardId, requestDto);
-        return ApiResponse.success(activityGroupBoardReferenceDto);
+        ActivityGroupBoardReferenceDto referenceDto = activityGroupBoardService.updateActivityGroupBoard(activityGroupBoardId, requestDto);
+        return ApiResponse.success(referenceDto);
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 삭제", description = "ROLE_USER 이상의 권한이 필요함")
@@ -142,8 +142,8 @@ public class ActivityGroupBoardController {
     public ApiResponse<ActivityGroupBoardReferenceDto> deleteActivityGroupBoard(
             @RequestParam Long activityGroupBoardId
     ) throws PermissionDeniedException {
-        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.deleteActivityGroupBoard(activityGroupBoardId);
-        return ApiResponse.success(activityGroupBoardReferenceDto);
+        ActivityGroupBoardReferenceDto referenceDto = activityGroupBoardService.deleteActivityGroupBoard(activityGroupBoardId);
+        return ApiResponse.success(referenceDto);
     }
 
     @Operation(summary = "[S] 삭제된 활동 그룹 게시판 조회하기", description = "ROLE_SUPER 이상의 권한이 필요함")

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
@@ -56,8 +56,8 @@ public class ActivityGroupBoardController {
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @Valid @RequestBody ActivityGroupBoardRequestDto requestDto
     ) throws PermissionDeniedException {
-        ActivityGroupBoardReferenceDto activityGroupBoard = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
-        return ApiResponse.success(activityGroupBoard);
+        ActivityGroupBoardReferenceDto activityGroupBoardReferenceDto = activityGroupBoardService.createActivityGroupBoard(parentId, activityGroupId, requestDto);
+        return ApiResponse.success(activityGroupBoardReferenceDto);
     }
 
     @Operation(summary = "[U] 활동 그룹 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -19,6 +19,7 @@ import page.clab.api.domain.activity.activitygroup.domain.GroupSchedule;
 import page.clab.api.domain.activity.activitygroup.dto.param.GroupScheduleDto;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupRequestDto;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupUpdateRequestDto;
+import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardStatusUpdatedResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupMemberWithApplyReasonResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupResponseDto;
 import page.clab.api.domain.memberManagement.member.domain.Member;
@@ -68,7 +69,7 @@ public class ActivityGroupAdminService {
     }
 
     @Transactional
-    public Long manageActivityGroup(Long activityGroupId, ActivityGroupStatus status) {
+    public ActivityGroupBoardStatusUpdatedResponseDto manageActivityGroup(Long activityGroupId, ActivityGroupStatus status) {
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
         activityGroup.updateStatus(status);
         activityGroupRepository.save(activityGroup);
@@ -77,7 +78,7 @@ public class ActivityGroupAdminService {
         if (groupLeader != null) {
             externalSendNotificationUseCase.sendNotificationToMember(groupLeader.getMemberId(), "활동 그룹이 [" + status.getDescription() + "] 상태로 변경되었습니다.");
         }
-        return activityGroup.getId();
+        return ActivityGroupBoardStatusUpdatedResponseDto.toDto(activityGroupId, status);
     }
 
     @Transactional(readOnly = true)
@@ -155,7 +156,7 @@ public class ActivityGroupAdminService {
     }
 
     @Transactional
-    public String manageGroupMemberStatus(Long activityGroupId, String memberId, GroupMemberStatus status) throws PermissionDeniedException {
+    public Long manageGroupMemberStatus(Long activityGroupId, String memberId, GroupMemberStatus status) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
         if (!isMemberGroupLeaderRole(activityGroup, currentMember)) {
@@ -169,7 +170,7 @@ public class ActivityGroupAdminService {
         activityGroupMemberService.save(groupMember);
 
         externalSendNotificationUseCase.sendNotificationToMember(member.getId(), "활동 그룹 신청이 [" + status.getDescription() + "] 상태로 변경되었습니다.");
-        return groupMember.getMemberId();
+        return activityGroup.getId();
     }
 
     public ActivityGroup getActivityGroupByIdOrThrow(Long activityGroupId) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dto/response/ActivityGroupBoardReferenceDto.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dto/response/ActivityGroupBoardReferenceDto.java
@@ -1,0 +1,21 @@
+package page.clab.api.domain.activity.activitygroup.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ActivityGroupBoardReferenceDto {
+
+    private Long id;
+    private Long groupId;
+    private Long parentId;
+
+    public static ActivityGroupBoardReferenceDto toDto(Long id, Long groupId, Long parentId) {
+        return ActivityGroupBoardReferenceDto.builder()
+                .id(id)
+                .groupId(groupId)
+                .parentId(parentId)
+                .build();
+    }
+}

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dto/response/ActivityGroupBoardStatusUpdatedResponseDto.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dto/response/ActivityGroupBoardStatusUpdatedResponseDto.java
@@ -1,0 +1,20 @@
+package page.clab.api.domain.activity.activitygroup.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupStatus;
+
+@Getter
+@Builder
+public class ActivityGroupBoardStatusUpdatedResponseDto {
+
+    private Long id;
+    private ActivityGroupStatus activityGroupStatus;
+
+    public static ActivityGroupBoardStatusUpdatedResponseDto toDto(Long groupId, ActivityGroupStatus activityGroupStatus) {
+        return ActivityGroupBoardStatusUpdatedResponseDto.builder()
+                .id(groupId)
+                .activityGroupStatus(activityGroupStatus)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

> #467 

프론트 @Jeong-Ag님이 활동 그룹 부분의 API 연동 작업을 하시면서 응답으로 반환되는 값 또는 DTO의 수정을 원하셨습니다. 관련된 내용을 작업한 PR 입니다.

## Tasks

- 활동 그룹 게시판 생성, 삭제, 수정 API의 반환값을 id, groupId, parentId로 수정
- 신청 멤버 상태 변경 API의 반환값을 groupId로 수정
 - 활동 상태 변경 API의 반환값을 groupId, status로 수정. 이때 groupId 값은 id 변수명으로 매핑

## Screenshot
**활동 상태 변경 시 반환값으로 groupId, status 전달**
![image](https://github.com/user-attachments/assets/ef5b8ad9-ea8d-4837-803d-68111a95d0a6)

**활동 그룹 게시판 생성 시 id, groupId, parentId 전달**
![image](https://github.com/user-attachments/assets/ab501b9e-5e9c-4e32-9a63-52c379425f08)

**활동 그룹 게시판 수정 시 id, groupId, parentId 전달**
![image](https://github.com/user-attachments/assets/0a0e9cf2-bc52-41e1-87cb-128a73d294cc)

**활동 그룹 게시판 삭제 시 id, groupId, parentId 전달**
![image](https://github.com/user-attachments/assets/735c9105-07d2-42b0-977b-51c74806cd29)

**신청 멤버 상태 변경 시 groupId 전달**
![image](https://github.com/user-attachments/assets/587e664d-e345-490d-9575-822c053e4fc4)

