### PR TITLE
feat(Slack): 도서 대여 신청 운영진 슬랙 알림 기능 추가 완료

### DIFF
--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -11,6 +11,7 @@ import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.common.slack.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackBookLoanRecordInfo;
 import page.clab.api.global.common.slack.domain.SlackMembershipFeeInfo;
 import page.clab.api.global.common.slack.event.NotificationEvent;
 import page.clab.api.global.config.SlackConfig;
@@ -50,6 +51,10 @@ public class SlackService {
 
     public void sendNewMembershipFeeNotification(SlackMembershipFeeInfo membershipFee) {
         eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_MEMBERSHIP_FEE, null, membershipFee));
+    }
+
+    public void sendNewBookLoanRequestNotification(SlackBookLoanRecordInfo bookLoanRecord) {
+        eventPublisher.publishEvent(new NotificationEvent(this, executivesWebhookUrl, ExecutivesAlertType.NEW_BOOK_LOAN_REQUEST, null, bookLoanRecord));
     }
 
     @EventListener(ContextRefreshedEvent.class)

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -27,6 +27,7 @@ import page.clab.api.global.common.slack.domain.ExecutivesAlertType;
 import page.clab.api.global.common.slack.domain.GeneralAlertType;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.common.slack.domain.SlackBoardInfo;
+import page.clab.api.global.common.slack.domain.SlackBookLoanRecordInfo;
 import page.clab.api.global.common.slack.domain.SlackMembershipFeeInfo;
 import page.clab.api.global.config.SlackConfig;
 import page.clab.api.global.util.HttpReqResUtil;
@@ -132,6 +133,11 @@ public class SlackServiceHelper {
                     if (additionalData instanceof SlackMembershipFeeInfo) {
                         return createMembershipFeeBlocks((SlackMembershipFeeInfo) additionalData);
                     }
+                case NEW_BOOK_LOAN_REQUEST:
+                    if (additionalData instanceof SlackBookLoanRecordInfo) {
+                        return createBookLoanRecordBlocks((SlackBookLoanRecordInfo) additionalData);
+                    }
+                    break;
                 default:
                     log.error("Unknown alert type: {}", alertType);
                     return List.of();
@@ -194,13 +200,13 @@ public class SlackServiceHelper {
     private List<LayoutBlock> createApplicationBlocks(ApplicationRequestDto requestDto) {
         List<LayoutBlock> blocks = new ArrayList<>();
 
-        blocks.add(section(section -> section.text(markdownText(":sparkles: *New Application*"))));
+        blocks.add(section(section -> section.text(markdownText(":sparkles: *동아리 지원*"))));
         blocks.add(section(section -> section.fields(Arrays.asList(
-                markdownText("*Type:*\n" + requestDto.getApplicationType().getDescription()),
-                markdownText("*Student ID:*\n" + requestDto.getStudentId()),
-                markdownText("*Name:*\n" + requestDto.getName()),
-                markdownText("*Grade:*\n" + requestDto.getGrade() + "학년"),
-                markdownText("*Interests:*\n" + requestDto.getInterests())
+                markdownText("*구분:*\n" + requestDto.getApplicationType().getDescription()),
+                markdownText("*학번:*\n" + requestDto.getStudentId()),
+                markdownText("*이름:*\n" + requestDto.getName()),
+                markdownText("*학년:*\n" + requestDto.getGrade() + "학년"),
+                markdownText("*관심 분야:*\n" + requestDto.getInterests())
         ))));
 
         if (requestDto.getGithubUrl() != null && !requestDto.getGithubUrl().isEmpty()) {
@@ -216,11 +222,11 @@ public class SlackServiceHelper {
     private List<LayoutBlock> createBoardBlocks(SlackBoardInfo board) {
         List<LayoutBlock> blocks = new ArrayList<>();
 
-        blocks.add(section(section -> section.text(markdownText(":writing_hand: *New Board*"))));
+        blocks.add(section(section -> section.text(markdownText(":writing_hand: *새 게시글*"))));
         blocks.add(section(section -> section.fields(Arrays.asList(
-                markdownText("*Title:*\n" + board.getTitle()),
-                markdownText("*Category:*\n" + board.getCategory()),
-                markdownText("*User:*\n" + board.getUsername())
+                markdownText("*제목:*\n" + board.getTitle()),
+                markdownText("*분류:*\n" + board.getCategory()),
+                markdownText("*작성자:*\n" + board.getUsername())
         ))));
         return blocks;
     }
@@ -229,13 +235,27 @@ public class SlackServiceHelper {
         String username = additionalData.getMemberId() + " " + additionalData.getMemberName();
 
         return Arrays.asList(
-                section(section -> section.text(markdownText(":dollar: *New Membership Fee*"))),
+                section(section -> section.text(markdownText(":dollar: *회비 신청*"))),
                 section(section -> section.fields(Arrays.asList(
-                        markdownText("*User:*\n" + username),
-                        markdownText("*Category:*\n" + additionalData.getCategory()),
-                        markdownText("*Amount:*\n" + additionalData.getAmount() + "원")
+                        markdownText("*신청자:*\n" + username),
+                        markdownText("*분류:*\n" + additionalData.getCategory()),
+                        markdownText("*금액:*\n" + additionalData.getAmount() + "원")
                 ))),
                 section(section -> section.text(markdownText("*Content:*\n" + additionalData.getContent())))
+        );
+    }
+
+    private List<LayoutBlock> createBookLoanRecordBlocks(SlackBookLoanRecordInfo additionalData) {
+        String username = additionalData.getMemberId() + " " + additionalData.getMemberName();
+
+        return Arrays.asList(
+                section(section -> section.text(markdownText(":books: *도서 대여 신청*"))),
+                section(section -> section.fields(Arrays.asList(
+                        markdownText("*도서명:*\n" + additionalData.getBookTitle()),
+                        markdownText("*분류:*\n" + additionalData.getCategory()),
+                        markdownText("*신청자:*\n" + username),
+                        markdownText("*상태:*\n" + (additionalData.isAvailable() ? "대여 가능" : "대여 중"))
+                )))
         );
     }
 

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -133,6 +133,7 @@ public class SlackServiceHelper {
                     if (additionalData instanceof SlackMembershipFeeInfo) {
                         return createMembershipFeeBlocks((SlackMembershipFeeInfo) additionalData);
                     }
+                    break;
                 case NEW_BOOK_LOAN_REQUEST:
                     if (additionalData instanceof SlackBookLoanRecordInfo) {
                         return createBookLoanRecordBlocks((SlackBookLoanRecordInfo) additionalData);

--- a/src/main/java/page/clab/api/global/common/slack/domain/ExecutivesAlertType.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/ExecutivesAlertType.java
@@ -9,7 +9,8 @@ public enum ExecutivesAlertType implements AlertType {
 
     NEW_APPLICATION("새 지원서", "New application has been submitted."),
     NEW_BOARD("새 게시글", "New board has been posted."),
-    NEW_MEMBERSHIP_FEE("새 회비 신청", "New membership fee has been submitted.");
+    NEW_MEMBERSHIP_FEE("새 회비 신청", "New membership fee has been submitted."),
+    NEW_BOOK_LOAN_REQUEST("도서 대출 신청", "New book loan request has been submitted.");
 
     private final String title;
     private final String defaultMessage;

--- a/src/main/java/page/clab/api/global/common/slack/domain/SlackBookLoanRecordInfo.java
+++ b/src/main/java/page/clab/api/global/common/slack/domain/SlackBookLoanRecordInfo.java
@@ -1,0 +1,27 @@
+package page.clab.api.global.common.slack.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import page.clab.api.domain.library.book.domain.Book;
+import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBorrowerInfoDto;
+
+@Getter
+@Builder
+public class SlackBookLoanRecordInfo {
+
+    private String memberId;
+    private String memberName;
+    private String bookTitle;
+    private String category;
+    private boolean isAvailable;
+
+    public static SlackBookLoanRecordInfo create(Book book, MemberBorrowerInfoDto borrowerInfo) {
+        return SlackBookLoanRecordInfo.builder()
+                .memberId(borrowerInfo.getMemberId())
+                .memberName(borrowerInfo.getMemberName())
+                .bookTitle(book.getTitle())
+                .category(book.getCategory())
+                .isAvailable(book.getBorrowerId() == null)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

> #472 

운영진들이 도서 대여 신청 내역을 실시간으로 확인할 수 있도록, 도서 대여 신청 시 운영진 전용 슬랙 채널로 알림을 보내는 기능을 추가했습니다.

## Tasks

- 도서 대여 신청 알림 자동화
    - 도서 대여 신청이 들어올 경우, 신청자의 기본 정보와 함께 운영진 전용 슬랙 채널로 알림이 자동으로 전송되도록 구현.
- 운영진 채널 슬랙 알림 한글화

## Screenshot

![image](https://github.com/user-attachments/assets/250d9efb-7546-42b8-9f16-19346ed6fc4b)