### PR TITLE
feat: 모집 공고 절차 추가 및 관련 API 구현 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/hiring/application/application/dto/response/ApplicationPassResponseDto.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/application/dto/response/ApplicationPassResponseDto.java
@@ -22,4 +22,10 @@ public class ApplicationPassResponseDto {
                 .isPass(application.getIsPass())
                 .build();
     }
+
+    public static ApplicationPassResponseDto defaultResponse() {
+        return ApplicationPassResponseDto.builder()
+                .isPass(false)
+                .build();
+    }
 }

--- a/src/main/java/page/clab/api/domain/hiring/application/application/exception/RecruitmentEndDateExceededException.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/application/exception/RecruitmentEndDateExceededException.java
@@ -1,0 +1,8 @@
+package page.clab.api.domain.hiring.application.application.exception;
+
+public class RecruitmentEndDateExceededException extends RuntimeException {
+
+    public RecruitmentEndDateExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationPassCheckService.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationPassCheckService.java
@@ -7,17 +7,24 @@ import page.clab.api.domain.hiring.application.adapter.out.persistence.Applicati
 import page.clab.api.domain.hiring.application.application.dto.response.ApplicationPassResponseDto;
 import page.clab.api.domain.hiring.application.application.port.in.CheckApplicationPassStatusUseCase;
 import page.clab.api.domain.hiring.application.application.port.out.RetrieveApplicationPort;
+import page.clab.api.domain.hiring.recruitment.application.port.out.RetrieveRecruitmentPort;
+import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
 
 @Service
 @RequiredArgsConstructor
 public class ApplicationPassCheckService implements CheckApplicationPassStatusUseCase {
 
     private final RetrieveApplicationPort retrieveApplicationPort;
+    private final RetrieveRecruitmentPort retrieveRecruitmentPort;
 
     @Transactional(readOnly = true)
     @Override
     public ApplicationPassResponseDto checkPassStatus(Long recruitmentId, String studentId) {
         ApplicationId id = ApplicationId.create(studentId, recruitmentId);
+        Recruitment recruitment = retrieveRecruitmentPort.findByIdOrThrow(recruitmentId);
+
+        recruitment.validateEndDateWithin7Days();
+
         return retrieveApplicationPort.findById(id)
                 .map(ApplicationPassResponseDto::toDto)
                 .orElseGet(ApplicationPassResponseDto::defaultResponse);

--- a/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationPassCheckService.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationPassCheckService.java
@@ -20,10 +20,6 @@ public class ApplicationPassCheckService implements CheckApplicationPassStatusUs
         ApplicationId id = ApplicationId.create(studentId, recruitmentId);
         return retrieveApplicationPort.findById(id)
                 .map(ApplicationPassResponseDto::toDto)
-                .orElseGet(() ->
-                        ApplicationPassResponseDto.builder()
-                                .isPass(false)
-                                .build()
-                );
+                .orElseGet(ApplicationPassResponseDto::defaultResponse);
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecentRecruitmentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecentRecruitmentsRetrievalController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentEndDateResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.port.in.RetrieveRecentRecruitmentsUseCase;
 import page.clab.api.global.common.dto.ApiResponse;
@@ -25,6 +26,13 @@ public class RecentRecruitmentsRetrievalController {
     @GetMapping("")
     public ApiResponse<List<RecruitmentResponseDto>> retrieveRecentRecruitments() {
         List<RecruitmentResponseDto> recruitments = retrieveRecentRecruitmentsUseCase.retrieveRecentRecruitments();
+        return ApiResponse.success(recruitments);
+    }
+    
+    @Operation(summary = "모집 종료 기간 기준 최신 일주일 모집 공고 목록", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @GetMapping("/recent-week")
+    public ApiResponse<List<RecruitmentEndDateResponseDto>> retrieveRecruitmentsByEndDate() {
+        List<RecruitmentEndDateResponseDto> recruitments = retrieveRecentRecruitmentsUseCase.retrieveRecruitmentsByEndDate();
         return ApiResponse.success(recruitments);
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentPersistenceAdapter.java
@@ -8,6 +8,7 @@ import page.clab.api.domain.hiring.recruitment.application.port.out.UpdateRecrui
 import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
 import page.clab.api.global.exception.NotFoundException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -56,9 +57,9 @@ public class RecruitmentPersistenceAdapter implements
     }
 
     @Override
-    public void existsByIdOrThrow(Long recruitmentId) {
-        if (!repository.existsById(recruitmentId)) {
-            throw new NotFoundException("[Recruitment] id: " + recruitmentId + "에 해당하는 모집 공고가 존재하지 않습니다.");
-        }
+    public List<Recruitment> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now) {
+        return repository.findByEndDateBetween(weekAgo, now).stream()
+                .map(mapper::toDomainEntity)
+                .toList();
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentRepository.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentRepository.java
@@ -3,9 +3,13 @@ package page.clab.api.domain.hiring.recruitment.adapter.out.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<RecruitmentJpaEntity, Long> {
+
     List<RecruitmentJpaEntity> findTop5ByOrderByCreatedAtDesc();
+
+    List<RecruitmentJpaEntity> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now);
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/response/RecruitmentEndDateResponseDto.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/response/RecruitmentEndDateResponseDto.java
@@ -1,0 +1,29 @@
+package page.clab.api.domain.hiring.recruitment.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import page.clab.api.domain.hiring.application.domain.ApplicationType;
+import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RecruitmentEndDateResponseDto {
+
+    private Long id;
+    private ApplicationType applicationType;
+
+    public static List<RecruitmentEndDateResponseDto> toDto(List<Recruitment> recruitments) {
+        return recruitments.stream()
+                .map(RecruitmentEndDateResponseDto::toDto)
+                .toList();
+    }
+
+    public static RecruitmentEndDateResponseDto toDto(Recruitment recruitment) {
+        return RecruitmentEndDateResponseDto.builder()
+                .id(recruitment.getId())
+                .applicationType(recruitment.getApplicationType())
+                .build();
+    }
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RetrieveRecentRecruitmentsUseCase.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RetrieveRecentRecruitmentsUseCase.java
@@ -1,9 +1,13 @@
 package page.clab.api.domain.hiring.recruitment.application.port.in;
 
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentEndDateResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentResponseDto;
 
 import java.util.List;
 
 public interface RetrieveRecentRecruitmentsUseCase {
+
     List<RecruitmentResponseDto> retrieveRecentRecruitments();
+
+    List<RecruitmentEndDateResponseDto> retrieveRecruitmentsByEndDate();
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/out/RetrieveRecruitmentPort.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/out/RetrieveRecruitmentPort.java
@@ -2,6 +2,7 @@ package page.clab.api.domain.hiring.recruitment.application.port.out;
 
 import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RetrieveRecruitmentPort {
@@ -12,5 +13,5 @@ public interface RetrieveRecruitmentPort {
 
     List<Recruitment> findTop5ByOrderByCreatedAtDesc();
 
-    void existsByIdOrThrow(Long recruitmentId);
+    List<Recruitment> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now);
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/RecentRecruitmentsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/RecentRecruitmentsRetrievalService.java
@@ -3,10 +3,13 @@ package page.clab.api.domain.hiring.recruitment.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentEndDateResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.port.in.RetrieveRecentRecruitmentsUseCase;
 import page.clab.api.domain.hiring.recruitment.application.port.out.RetrieveRecruitmentPort;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -20,6 +23,18 @@ public class RecentRecruitmentsRetrievalService implements RetrieveRecentRecruit
     public List<RecruitmentResponseDto> retrieveRecentRecruitments() {
         return retrieveRecruitmentPort.findTop5ByOrderByCreatedAtDesc().stream()
                 .map(RecruitmentResponseDto::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<RecruitmentEndDateResponseDto> retrieveRecruitmentsByEndDate() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime weekAgo = now.minusWeeks(1).with(LocalTime.MIN);
+        LocalDateTime endOfDay = now.with(LocalTime.MAX);
+
+        return retrieveRecruitmentPort.findByEndDateBetween(weekAgo, endOfDay).stream()
+                .map(RecruitmentEndDateResponseDto::toDto)
                 .toList();
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/domain/Recruitment.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/domain/Recruitment.java
@@ -6,11 +6,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import page.clab.api.domain.hiring.application.application.exception.RecruitmentEndDateExceededException;
 import page.clab.api.domain.hiring.application.application.exception.RecruitmentNotActiveException;
 import page.clab.api.domain.hiring.application.domain.ApplicationType;
 import page.clab.api.domain.hiring.recruitment.application.dto.request.RecruitmentUpdateRequestDto;
 import page.clab.api.global.exception.InvalidDateRangeException;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -55,5 +57,23 @@ public class Recruitment {
         if (startDate.isAfter(endDate)) {
             throw new InvalidDateRangeException("시작일은 종료일보다 늦을 수 없습니다.");
         }
+    }
+
+    /**
+     * 모집 종료일이 현재 날짜 기준 7일 이내인지 확인하고, 그렇지 않은 경우 예외를 발생시킵니다.
+     *
+     * @throws RecruitmentEndDateExceededException 모집 종료일이 현재 날짜 기준 7일을 초과했거나, 아직 모집이 종료되지 않은 경우 발생
+     */
+    public void validateEndDateWithin7Days() {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = this.endDate.toLocalDate();
+
+        if (endDate.isBefore(today.minusDays(7)) || !this.isRecruitmentEnd()) {
+            throw new RecruitmentEndDateExceededException("지원 기간이 종료된 지 7일이 넘었거나, 아직 종료되지 않은 모집입니다.");
+        }
+    }
+
+    public boolean isRecruitmentEnd() {
+        return LocalDateTime.now().isAfter(endDate) || status.isClosed();
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/domain/RecruitmentStatus.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/domain/RecruitmentStatus.java
@@ -17,4 +17,8 @@ public enum RecruitmentStatus {
     public boolean isRecruiting() {
         return this.equals(RecruitmentStatus.OPEN);
     }
+
+    public boolean isClosed() {
+        return this.equals(RecruitmentStatus.CLOSED);
+    }
 }

--- a/src/main/java/page/clab/api/global/config/SecurityConstants.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConstants.java
@@ -17,7 +17,7 @@ public class SecurityConstants {
 
     public static final String[] PERMIT_ALL_API_ENDPOINTS_GET = {
             "/api/v1/applications/{studentId}",
-            "/api/v1/recruitments",
+            "/api/v1/recruitments", "/api/v1/recruitments/recent-week",
             "/api/v1/news", "/api/v1/news/**",
             "/api/v1/blogs", "/api/v1/blogs/**",
             "/api/v1/positions", "/api/v1/positions/**",

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -39,6 +39,7 @@ import page.clab.api.domain.auth.login.application.exception.LoginFailedExceptio
 import page.clab.api.domain.auth.login.application.exception.MemberLockedException;
 import page.clab.api.domain.community.accuse.application.exception.AccuseTargetTypeIncorrectException;
 import page.clab.api.domain.hiring.application.application.exception.NotApprovedApplicationException;
+import page.clab.api.domain.hiring.application.application.exception.RecruitmentEndDateExceededException;
 import page.clab.api.domain.hiring.application.application.exception.RecruitmentNotActiveException;
 import page.clab.api.domain.library.book.application.exception.BookAlreadyBorrowedException;
 import page.clab.api.domain.library.book.application.exception.InvalidBorrowerException;
@@ -96,6 +97,7 @@ public class GlobalExceptionHandler {
             InvalidEmojiException.class,
             InvalidRoleChangeException.class,
             RecruitmentNotActiveException.class,
+            RecruitmentEndDateExceededException.class,
             StringIndexOutOfBoundsException.class,
             MissingServletRequestParameterException.class,
             MalformedJsonException.class,


### PR DESCRIPTION
## Summary

> #479 

모집 공고 절차가 추가됨에 따라, 서버와 클라이언트 간의 통신을 명확히 하기 위한 API 구현 및 로직 개선 작업을 완료했습니다.

## Tasks

1. **최근 일주일 동안의 모집 공고 목록 반환 API 구현**
   - 모집 기간 종료일을 기준으로 최근 일주일 동안의 모집 공고 목록을 반환하는 API를 구현했습니다.
   - 클라이언트는 이 API를 통해 최신 모집 공고를 조회하고 사용자에게 표시할 수 있습니다.

2. **합격 여부 조회 기능 개선**
   - 클라이언트에서 특정 모집 공고 ID와 지원자의 학번 정보를 서버로 전달하면, 서버는 해당 모집 공고에 대한 합격 여부를 반환합니다.
   - 모집 공고가 종료된 지 일주일이 지난 경우에는 해당 공고에 대한 조회가 불가능하도록 처리했습니다.

3. **로직 개선 및 예외 처리**
   - 서버에서 모집 공고의 종료일을 기준으로 일주일이 지난 경우, 조회 시 예외가 발생하도록 로직을 추가했습니다.
   - 이를 통해 잘못된 정보가 클라이언트에 표시되는 것을 방지합니다.

## ETC

- 추가된 예외 처리 로직에 대한 문서를 작성했습니다.