### PR TITLE
fix: 도서 대출시 도서의 대출자 정보가 승인자로 저장되는 버그 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
@@ -25,10 +25,10 @@ public class BookDetailsRetrievalService implements RetrieveBookDetailsUseCase {
     @Transactional(readOnly = true)
     @Override
     public BookDetailsResponseDto retrieveBookDetails(Long bookId) {
-        String borrowerId = externalRetrieveBookLoanRecordUseCase.getBorrowerIdForBook(bookId);
-        MemberBasicInfoDto memberBasicInfo = externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId);
         Book book = retrieveBookPort.findByIdOrThrow(bookId);
-        return mapToBookDetailsResponseDto(book, memberBasicInfo.getMemberName());
+        String borrowerId = book.getBorrowerId();
+        String borrowerName = (borrowerId != null) ? externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName() : null;
+        return mapToBookDetailsResponseDto(book, borrowerName);
     }
 
     @NotNull

--- a/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
@@ -26,9 +26,16 @@ public class BookDetailsRetrievalService implements RetrieveBookDetailsUseCase {
     @Override
     public BookDetailsResponseDto retrieveBookDetails(Long bookId) {
         Book book = retrieveBookPort.findByIdOrThrow(bookId);
-        String borrowerId = book.getBorrowerId();
-        String borrowerName = (borrowerId != null) ? externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName() : null;
+        String borrowerName = getBorrowerName(book);
         return mapToBookDetailsResponseDto(book, borrowerName);
+    }
+
+    private String getBorrowerName(Book book) {
+        String borrowerId = book.getBorrowerId();
+        if (borrowerId != null) {
+            return externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName();
+        }
+        return null;
     }
 
     @NotNull

--- a/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BookDetailsRetrievalService.java
@@ -25,9 +25,10 @@ public class BookDetailsRetrievalService implements RetrieveBookDetailsUseCase {
     @Transactional(readOnly = true)
     @Override
     public BookDetailsResponseDto retrieveBookDetails(Long bookId) {
-        MemberBasicInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberBasicInfo();
+        String borrowerId = externalRetrieveBookLoanRecordUseCase.getBorrowerIdForBook(bookId);
+        MemberBasicInfoDto memberBasicInfo = externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId);
         Book book = retrieveBookPort.findByIdOrThrow(bookId);
-        return mapToBookDetailsResponseDto(book, currentMemberInfo.getMemberName());
+        return mapToBookDetailsResponseDto(book, memberBasicInfo.getMemberName());
     }
 
     @NotNull

--- a/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
@@ -34,8 +34,15 @@ public class BooksByConditionsRetrievalService implements RetrieveBooksByConditi
     @NotNull
     private BookResponseDto mapToBookResponseDto(Book book) {
         LocalDateTime dueDate = externalRetrieveBookLoanRecordUseCase.getDueDateForBook(book.getId());
+        String borrowerName = getBorrowerName(book);
+        return BookResponseDto.toDto(book, borrowerName, dueDate);
+    }
+
+    private String getBorrowerName(Book book) {
         String borrowerId = book.getBorrowerId();
-        String memberName = (borrowerId != null) ? externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName() : null;
-        return BookResponseDto.toDto(book, memberName, dueDate);
+        if (borrowerId != null) {
+            return externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName();
+        }
+        return null;
     }
 }

--- a/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
@@ -34,8 +34,9 @@ public class BooksByConditionsRetrievalService implements RetrieveBooksByConditi
 
     @NotNull
     private BookResponseDto mapToBookResponseDto(Book book) {
-        MemberBasicInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberBasicInfo();
+        String borrowerId = externalRetrieveBookLoanRecordUseCase.getBorrowerIdForBook(book.getId());
+        MemberBasicInfoDto memberBasicInfo = externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId);
         LocalDateTime dueDate = externalRetrieveBookLoanRecordUseCase.getDueDateForBook(book.getId());
-        return BookResponseDto.toDto(book, currentMemberInfo.getMemberName(), dueDate);
+        return BookResponseDto.toDto(book, memberBasicInfo.getMemberName(), dueDate);
     }
 }

--- a/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/library/book/application/service/BooksByConditionsRetrievalService.java
@@ -10,7 +10,6 @@ import page.clab.api.domain.library.book.application.dto.response.BookResponseDt
 import page.clab.api.domain.library.book.application.port.in.RetrieveBooksByConditionsUseCase;
 import page.clab.api.domain.library.book.application.port.out.RetrieveBookPort;
 import page.clab.api.domain.library.book.domain.Book;
-import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
 import page.clab.api.external.library.bookLoanRecord.application.port.ExternalRetrieveBookLoanRecordUseCase;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.common.dto.PagedResponseDto;
@@ -34,9 +33,9 @@ public class BooksByConditionsRetrievalService implements RetrieveBooksByConditi
 
     @NotNull
     private BookResponseDto mapToBookResponseDto(Book book) {
-        String borrowerId = externalRetrieveBookLoanRecordUseCase.getBorrowerIdForBook(book.getId());
-        MemberBasicInfoDto memberBasicInfo = externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId);
         LocalDateTime dueDate = externalRetrieveBookLoanRecordUseCase.getDueDateForBook(book.getId());
-        return BookResponseDto.toDto(book, memberBasicInfo.getMemberName(), dueDate);
+        String borrowerId = book.getBorrowerId();
+        String memberName = (borrowerId != null) ? externalRetrieveMemberUseCase.getMemberBasicInfoById(borrowerId).getMemberName() : null;
+        return BookResponseDto.toDto(book, memberName, dueDate);
     }
 }

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanApprovalService.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanApprovalService.java
@@ -11,7 +11,6 @@ import page.clab.api.domain.library.bookLoanRecord.application.port.out.Retrieve
 import page.clab.api.domain.library.bookLoanRecord.domain.BookLoanRecord;
 import page.clab.api.external.library.book.application.port.ExternalRegisterBookUseCase;
 import page.clab.api.external.library.book.application.port.ExternalRetrieveBookUseCase;
-import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 
 @Service
 @RequiredArgsConstructor
@@ -21,13 +20,12 @@ public class BookLoanApprovalService implements ApproveBookLoanUseCase {
     private final RegisterBookLoanRecordPort registerBookLoanRecordPort;
     private final ExternalRetrieveBookUseCase externalRetrieveBookUseCase;
     private final ExternalRegisterBookUseCase externalRegisterBookUseCase;
-    private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
 
     @Transactional
     @Override
     public Long approveBookLoan(Long bookLoanRecordId) {
-        String borrowerId = externalRetrieveMemberUseCase.getCurrentMemberId();
         BookLoanRecord bookLoanRecord = retrieveBookLoanRecordPort.findByIdOrThrow(bookLoanRecordId);
+        String borrowerId = bookLoanRecord.getBorrowerId();
         Book book = externalRetrieveBookUseCase.findByIdOrThrow(bookLoanRecord.getBookId());
 
         book.validateBookIsNotBorrowed();
@@ -46,3 +44,4 @@ public class BookLoanApprovalService implements ApproveBookLoanUseCase {
         }
     }
 }
+

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanApprovalService.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanApprovalService.java
@@ -44,4 +44,3 @@ public class BookLoanApprovalService implements ApproveBookLoanUseCase {
         }
     }
 }
-

--- a/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
+++ b/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
@@ -4,4 +4,6 @@ import java.time.LocalDateTime;
 
 public interface ExternalRetrieveBookLoanRecordUseCase {
     LocalDateTime getDueDateForBook(Long bookId);
+
+    String getBorrowerIdForBook(Long bookId);
 }

--- a/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
+++ b/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
@@ -3,6 +3,7 @@ package page.clab.api.external.library.bookLoanRecord.application.port;
 import java.time.LocalDateTime;
 
 public interface ExternalRetrieveBookLoanRecordUseCase {
+
     LocalDateTime getDueDateForBook(Long bookId);
 
     String getBorrowerIdForBook(Long bookId);

--- a/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
+++ b/src/main/java/page/clab/api/external/library/bookLoanRecord/application/port/ExternalRetrieveBookLoanRecordUseCase.java
@@ -5,6 +5,4 @@ import java.time.LocalDateTime;
 public interface ExternalRetrieveBookLoanRecordUseCase {
 
     LocalDateTime getDueDateForBook(Long bookId);
-
-    String getBorrowerIdForBook(Long bookId);
 }

--- a/src/main/java/page/clab/api/external/library/bookLoanRecord/application/service/ExternalBookLoanRecordRetrievalService.java
+++ b/src/main/java/page/clab/api/external/library/bookLoanRecord/application/service/ExternalBookLoanRecordRetrievalService.java
@@ -23,10 +23,4 @@ public class ExternalBookLoanRecordRetrievalService implements ExternalRetrieveB
                 .map(BookLoanRecord::getDueDate)
                 .orElse(null);
     }
-
-    @Override
-    public String getBorrowerIdForBook(Long bookId) {
-        BookLoanRecord bookLoanRecord = retrieveBookLoanRecordPort.findByIdOrThrow(bookId);
-        return bookLoanRecord.getBorrowerId();
-    }
 }

--- a/src/main/java/page/clab/api/external/library/bookLoanRecord/application/service/ExternalBookLoanRecordRetrievalService.java
+++ b/src/main/java/page/clab/api/external/library/bookLoanRecord/application/service/ExternalBookLoanRecordRetrievalService.java
@@ -23,4 +23,10 @@ public class ExternalBookLoanRecordRetrievalService implements ExternalRetrieveB
                 .map(BookLoanRecord::getDueDate)
                 .orElse(null);
     }
+
+    @Override
+    public String getBorrowerIdForBook(Long bookId) {
+        BookLoanRecord bookLoanRecord = retrieveBookLoanRecordPort.findByIdOrThrow(bookId);
+        return bookLoanRecord.getBorrowerId();
+    }
 }


### PR DESCRIPTION
## Summary

> #482 

도서 대출시, 책의 대출자 정보(`borrowerId`, `borrowName`)가 도서를 승인해주는 관리자의 정보로 저장되는 버그를 수정했습니다.

## Tasks

- 도서 승인시, 대출자 정보가 승인자 정보로 저장되는 로직 수정

## ETC

`202014941 송재훈`이 도서 대출을 하고, 관리자가 승인한 후, 도서 목록 조회를 한 원래의 결과입니다.
![스크린샷 2024-08-19 143241](https://github.com/user-attachments/assets/8ca5e0f2-7ef1-48c4-be92-1dee8dc2f150)


## Screenshot

- 도서 목록 조회
![스크린샷 2024-08-19 154432](https://github.com/user-attachments/assets/daf4ebdd-4dc9-47e2-a613-347be302b6be)

- 도서 상세 조회
![스크린샷 2024-08-19 155125](https://github.com/user-attachments/assets/cce6a792-9e86-405d-a9fd-58072636ebbf)

