### PR TITLE
fix: 멤버 권한 조회 API의 응답에서 메타데이터가 누락되는 문제 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRoleInfoRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/in/web/MemberRoleInfoRetrievalController.java
@@ -13,6 +13,7 @@ import page.clab.api.domain.memberManagement.member.application.dto.response.Mem
 import page.clab.api.domain.memberManagement.member.application.port.in.RetrieveMemberRoleInfoUseCase;
 import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.global.common.dto.ApiResponse;
+import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.InvalidColumnException;
 import page.clab.api.global.exception.SortingArgumentException;
 import page.clab.api.global.util.PageableUtils;
@@ -34,7 +35,7 @@ public class MemberRoleInfoRetrievalController {
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/roles")
-    public ApiResponse<List<MemberRoleInfoResponseDto>> retrieveMemberRoleInfo(
+    public ApiResponse<PagedResponseDto<MemberRoleInfoResponseDto>> retrieveMemberRoleInfo(
             @RequestParam(required = false) String memberId,
             @RequestParam(required = false) String memberName,
             @RequestParam(required = false) Role role,
@@ -44,7 +45,7 @@ public class MemberRoleInfoRetrievalController {
             @RequestParam(name = "sortDirection", defaultValue = "asc") List<String> sortDirection
     ) throws InvalidColumnException, SortingArgumentException {
         Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, MemberRoleInfoResponseDto.class);
-        List<MemberRoleInfoResponseDto> memberRoles = retrieveMemberRoleInfoUseCase.retrieveMemberRoleInfo(memberId, memberName, role, pageable);
+        PagedResponseDto<MemberRoleInfoResponseDto> memberRoles = retrieveMemberRoleInfoUseCase.retrieveMemberRoleInfo(memberId, memberName, role, pageable);
         return ApiResponse.success(memberRoles);
     }
 }

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -88,11 +88,9 @@ public class MemberPersistenceAdapter implements
                 .toList();
     }
 
-    public List<Member> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable) {
+    public Page<Member> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable) {
         Page<MemberJpaEntity> jpaEntities = memberRepository.findMemberRoleInfoByConditions(memberId, memberName, role, pageable);
-        return jpaEntities.stream()
-                .map(memberMapper::toDomainEntity)
-                .toList();
+        return jpaEntities.map(memberMapper::toDomainEntity);
     }
 
     @Override

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/port/in/RetrieveMemberRoleInfoUseCase.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/port/in/RetrieveMemberRoleInfoUseCase.java
@@ -3,9 +3,8 @@ package page.clab.api.domain.memberManagement.member.application.port.in;
 import org.springframework.data.domain.Pageable;
 import page.clab.api.domain.memberManagement.member.application.dto.response.MemberRoleInfoResponseDto;
 import page.clab.api.domain.memberManagement.member.domain.Role;
-
-import java.util.List;
+import page.clab.api.global.common.dto.PagedResponseDto;
 
 public interface RetrieveMemberRoleInfoUseCase {
-    List<MemberRoleInfoResponseDto> retrieveMemberRoleInfo(String memberId, String memberName, Role role, Pageable pageable);
+    PagedResponseDto<MemberRoleInfoResponseDto> retrieveMemberRoleInfo(String memberId, String memberName, Role role, Pageable pageable);
 }

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/port/out/RetrieveMemberPort.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/port/out/RetrieveMemberPort.java
@@ -16,7 +16,7 @@ public interface RetrieveMemberPort {
 
     List<Member> findAll();
 
-    List<Member> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable);
+    Page<Member> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable);
 
     Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
 

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberRoleInfoRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberRoleInfoRetrievalService.java
@@ -1,6 +1,7 @@
 package page.clab.api.domain.memberManagement.member.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,8 +10,7 @@ import page.clab.api.domain.memberManagement.member.application.port.in.Retrieve
 import page.clab.api.domain.memberManagement.member.application.port.out.RetrieveMemberPort;
 import page.clab.api.domain.memberManagement.member.domain.Member;
 import page.clab.api.domain.memberManagement.member.domain.Role;
-
-import java.util.List;
+import page.clab.api.global.common.dto.PagedResponseDto;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +20,8 @@ public class MemberRoleInfoRetrievalService implements RetrieveMemberRoleInfoUse
 
     @Transactional(readOnly = true)
     @Override
-    public List<MemberRoleInfoResponseDto> retrieveMemberRoleInfo(String memberId, String memberName, Role role, Pageable pageable) {
-        List<Member> members = retrieveMemberPort.findMemberRoleInfoByConditions(memberId, memberName, role, pageable);
-        return MemberRoleInfoResponseDto.toDto(members);
+    public PagedResponseDto<MemberRoleInfoResponseDto> retrieveMemberRoleInfo(String memberId, String memberName, Role role, Pageable pageable) {
+        Page<Member> members = retrieveMemberPort.findMemberRoleInfoByConditions(memberId, memberName, role, pageable);
+        return new PagedResponseDto<>(members.map(MemberRoleInfoResponseDto::toDto));
     }
 }


### PR DESCRIPTION
## Summary

> #491 

멤버 권한 조회 API에서 타입 지정 문제로 인해 메타데이터가 누락되는 문제를 수정합니다.

## Tasks

- `retrieveMemberRoleInfo()` 메소드의 반환형을 `PagedResponseDto<MemberRoleInfoResponseDto>`로 수정

## Response

```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": true,
    "totalPages": 2,
    "totalItems": 6,
    "take": 3,
    "items": [
      {
        "id": "201912156",
        "name": "홍길동",
        "role": "USER"
      },
      {
        "id": "202310000",
        "name": "홍길동",
        "role": "USER"
      },
      {
        "id": "202310001",
        "name": "홍길동",
        "role": "USER"
      }
    ]
  }
}
```
