### PR TITLE
feat: 파일 접근 보안 강화 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -183,6 +183,17 @@ public class ActivityGroupAdminService {
         return groupMember.isLeader() && member.isAdminRole();
     }
 
+    public boolean isMemberGroupLeaderRole(Long activityGroupId, String memberId) {
+        ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
+        Member member = externalRetrieveMemberUseCase.findByIdOrThrow(memberId);
+        try{
+            GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, member.getId());
+            return groupMember.isLeader() && member.isAdminRole();
+        } catch (NotFoundException e) {
+         return false;
+        }
+    }
+
     public boolean isMemberHasRoleInActivityGroup(Member member, ActivityGroupRole role, Long activityGroupId) {
         List<GroupMember> groupMemberList = activityGroupMemberService.getGroupMemberByMemberId(member.getId());
         ActivityGroup activityGroup = activityGroupMemberService.getActivityGroupByIdOrThrow(activityGroupId);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
@@ -36,4 +36,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
     boolean existsByActivityGroupAndMemberId(ActivityGroup activityGroup, String memberId);
 
     boolean existsByActivityGroupAndMemberIdAndStatus(ActivityGroup activityGroup, String memberId, GroupMemberStatus status);
+
+    boolean existsByActivityGroupIdAndMemberIdAndStatus(Long activityGroupId, String memberId, GroupMemberStatus status);
 }

--- a/src/main/java/page/clab/api/global/auth/filter/FileAccessControlFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/FileAccessControlFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -14,16 +13,15 @@ import page.clab.api.global.common.file.application.FileService;
 import page.clab.api.global.util.ResponseUtil;
 
 @RequiredArgsConstructor
-@Slf4j
 public class FileAccessControlFilter extends OncePerRequestFilter {
 
     private final FileService fileService;
+    private final String fileURL;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String requestURI = request.getRequestURI();
-
-        if (requestURI.startsWith("/resources/files/")) {
+        if (requestURI.startsWith(fileURL)) {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             if (!fileService.isUserAccessibleAtFile(authentication, requestURI)) {
                 ResponseUtil.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/page/clab/api/global/auth/filter/FileAccessControlFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/FileAccessControlFilter.java
@@ -1,0 +1,36 @@
+package page.clab.api.global.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import page.clab.api.global.common.file.application.FileService;
+import page.clab.api.global.util.ResponseUtil;
+
+@RequiredArgsConstructor
+@Slf4j
+public class FileAccessControlFilter extends OncePerRequestFilter {
+
+    private final FileService fileService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        if (requestURI.startsWith("/resources/files/")) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (!fileService.isUserAccessibleAtFile(authentication, requestURI)) {
+                ResponseUtil.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
+++ b/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
@@ -22,4 +22,8 @@ public class AuthUtil {
     public static String getAuthenticationInfoMemberId() {
         return getAuthenticationInfo().getUsername();
     }
+
+    public static Boolean isUserUnAuthenticated (Authentication authentication) {
+        return (authentication == null || authentication.getAuthorities() == null || authentication.getAuthorities().isEmpty());
+    }
 }

--- a/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
+++ b/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
@@ -23,7 +23,7 @@ public class AuthUtil {
         return getAuthenticationInfo().getUsername();
     }
 
-    public static Boolean isUserUnAuthenticated (Authentication authentication) {
+    public static Boolean isUserUnAuthenticated(Authentication authentication) {
         return (authentication == null || authentication.getAuthorities() == null || authentication.getAuthorities().isEmpty());
     }
 }

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -223,42 +223,6 @@ public class FileService {
                 activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, authentication.getName());
     }
 
-/*    public boolean isUserAccessibleByCategory(String category, String url, Authentication authentication) {
-
-        if (category.equals("activity-photos")) {
-            return true;
-        }
-
-        if (authentication == null || authentication.getAuthorities() == null || authentication.getAuthorities().isEmpty())
-            return false;
-
-        UploadedFile uploadedFile = uploadedFileService.getUploadedFileByUrl(url);
-        String uploaderId = uploadedFile.getUploader();
-        GrantedAuthority authority = authentication.getAuthorities().iterator().next();
-        String roleName = authority.getAuthority().replace("ROLE_", "");
-        Role role = Role.valueOf(roleName);
-
-        if (!roleCategoryMap.getOrDefault(role, Set.of()).contains(category)) {
-            return false;
-        }
-
-        switch (category) {
-            case "boards", "profiles", "membership-fee", "activity-photos":
-                return true;
-
-            case "members":
-                return (authentication.getName().equals(uploaderId));
-
-            case "assignments":
-                String[] parts = url.split("/");
-                Long activityGroupId = Long.parseLong(parts[4]);
-                return (authentication.getName().equals(uploaderId) ||
-                        activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, authentication.getName()));
-            default:
-                return false;
-        }
-    }*/
-
     private String getCategoryByUrl(String url) {
         String basePath = fileURL + "/";
         String category = "";

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -61,10 +61,10 @@ public class FileService {
     private String maxFileSize;
 
     private static final Map<Role, Set<String>> roleCategoryMap = Map.of(
-            Role.GUEST, Set.of("boards", "profiles", "activity-photos", "membership-fees"),
-            Role.USER, Set.of("boards", "profiles", "activity-photos", "membership-fees", "assignments"),
-            Role.ADMIN, Set.of("boards", "profiles", "activity-photos", "membership-fees", "members", "assignments"),
-            Role.SUPER, Set.of("boards", "profiles", "activity-photos", "membership-fees", "members", "assignments")
+            Role.GUEST, Set.of("boards", "profiles", "activity-photos", "membership-fees", "weekly-activities"),
+            Role.USER, Set.of("boards", "profiles", "activity-photos", "membership-fees" , "weekly-activities", "assignments"),
+            Role.ADMIN, Set.of("boards", "profiles", "activity-photos", "membership-fees", "weekly-activities", "members", "assignments"),
+            Role.SUPER, Set.of("boards", "profiles", "activity-photos", "membership-fees", "weekly-activities", "members", "assignments")
     );
 
     private final Map<String, BiFunction<String, Authentication, Boolean>> categoryAccessMap = Map.of(
@@ -72,6 +72,7 @@ public class FileService {
             "profiles", (url, auth) -> true,
             "membership-fees", (url, auth) -> true,
             "activity-photos", (url, auth) -> true,
+            "weekly-activities", (url, auth) -> true,
             "members", this::isMemberAccessible,
             "assignments", this::isAssignmentAccessible
     );

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -29,10 +29,12 @@ import page.clab.api.external.auth.redisIpAccessMonitor.application.port.Externa
 import page.clab.api.external.auth.redisToken.application.port.ExternalManageRedisTokenUseCase;
 import page.clab.api.global.auth.application.WhitelistService;
 import page.clab.api.global.auth.filter.CustomBasicAuthenticationFilter;
+import page.clab.api.global.auth.filter.FileAccessControlFilter;
 import page.clab.api.global.auth.filter.InvalidEndpointAccessFilter;
 import page.clab.api.global.auth.filter.IpAuthenticationFilter;
 import page.clab.api.global.auth.filter.JwtAuthenticationFilter;
 import page.clab.api.global.auth.jwt.JwtTokenProvider;
+import page.clab.api.global.common.file.application.FileService;
 import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.filter.IPinfoSpringFilter;
 import page.clab.api.global.util.HttpReqResUtil;
@@ -60,6 +62,7 @@ public class SecurityConfig {
     private final AuthenticationConfig authenticationConfig;
     private final CorsConfigurationSource corsConfigurationSource;
     private final JwtTokenProvider jwtTokenProvider;
+    private final FileService fileService;
 
     @Value("${resource.file.url}")
     String fileURL;
@@ -97,6 +100,10 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(slackService, jwtTokenProvider, externalManageRedisTokenUseCase, externalCheckIpBlockedUseCase, externalRetrieveBlacklistIpUseCase),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .addFilterBefore(
+                        new FileAccessControlFilter(fileService),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer ->

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -103,7 +103,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(
-                        new FileAccessControlFilter(fileService),
+                        new FileAccessControlFilter(fileService, fileURL),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer ->

--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -1,7 +1,6 @@
 package page.clab.api.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package page.clab.api.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
## Summary

> #502

업로드된 파일에 URL로 접근할 때 파일 카테고리마다 적절한 접근 기준에 따라 파일을 반환하도록 하였습니다. **파일경로에 접근할 때 JWT와 함께 요청**을 보내야 합니다.

- `"boards", "profiles", "activity-photos", "membership-fee"` 의 경우 GUEST 이상인 경우 접근가능
-  `"members"`의 경우 업로드 본인만 접근가능
-  `"assignments"`의 경우 제출자와 스터디장, ADMIN 이상인 경우 접근 가능

## Tasks

업로드된 파일 접근 권한 검사 후 제어

## ETC
- 해당 작업내용이 적용되면 **파일 접근 시 JWT를 함께 담아서 요청**해야 하는데, 프론트에서 파일 접근 로직에  코드 수정이 일어날 것 같습니다. **제가 구현한 방향이 맞는지 확인부탁드립니다**.

## Screenshot

- 활동사진은 GUEST 로그인 이상의 경우 파일 반환
![image](https://github.com/user-attachments/assets/02a20cf5-cc25-4564-9753-b24503ff3bd1)

- 개인 클라우드 경로 파일은 본인만 확인가능 아래는 GUEST 로그인한 사용자로 접근한 경우
![image](https://github.com/user-attachments/assets/fe32fba7-ad82-4113-bbf0-d61d159dda42)

- 과제의 경우 제출자와 스터디장, ADMIN 사용자만 확인가능
![image](https://github.com/user-attachments/assets/96c1a893-5953-47e3-8013-da9901622566)
![image](https://github.com/user-attachments/assets/d351db56-b04c-49c7-93cd-f2f6080bb146)


