### PR TITLE
refactor : 활동 도메인에서 발생하는 알림 내용 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -214,6 +214,19 @@ public class ActivityGroupBoardService {
         }
     }
 
+    /**
+     * 새 게시판 생성에 대한 알림을 활동 그룹 멤버들에게 전송합니다.
+     *
+     * <p>이 메서드는 활동 그룹에서 새 게시판이 생성될 때 관련 멤버들에게 알림을 전송합니다.
+     * 만약 게시판을 생성한 멤버가 그룹 리더일 경우, 본인을 제외한 다른 모든 멤버들에게 알림이 전송됩니다.
+     * 단, 게시판이 피드백 유형일 경우에는 과제 제출한 멤버에게만 알림이 전송됩니다.
+     * 만약 게시판을 생성한 멤버가 팀원인 경우, 그룹 리더에게만 알림이 전송됩니다.</p>
+     *
+     * @param activityGroupId 게시판이 생성된 활동 그룹의 ID
+     * @param activityGroup 게시판이 생성된 활동 그룹
+     * @param board 생성된 게시판 객체
+     * @param member 게시판을 생성한 멤버 객체
+     */
     private void notifyMembersAboutNewBoard(Long activityGroupId, ActivityGroup activityGroup, ActivityGroupBoard board, Member member) {
         GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, member.getId());
         if (groupMember.isLeader()) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -184,6 +184,10 @@ public class ActivityGroupMemberService {
         return groupMemberRepository.findAllByActivityGroupId(activityGroupId, pageable);
     }
 
+    public List<GroupMember> getGroupMemberByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status) {
+        return groupMemberRepository.findAllByActivityGroupIdAndStatus(activityGroupId, status);
+    }
+
     public Page<GroupMember> getGroupMemberByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status, Pageable pageable) {
         return groupMemberRepository.findAllByActivityGroupIdAndStatus(activityGroupId, status, pageable);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
@@ -31,5 +31,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
 
     Page<GroupMember> findAllByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status, org.springframework.data.domain.Pageable pageable);
 
+    List<GroupMember> findAllByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status);
+
     boolean existsByActivityGroupAndMemberId(ActivityGroup activityGroup, String memberId);
 }


### PR DESCRIPTION

## Summary

> #501 

활동 게시판 생성시 "새 게시글"이라는 멘트를 카테고리명으로 수정하였습니다.

활동 게시판 생성 알림을 팀원, 팀장별로 다르게 전송하도록 하였습니다.
팀장의 경우 본인이 등록한 게시글 이외의 모든 새 게시글 알림을 받고,
팀원의 경우 팀장이 등록하는 주차별 활동, 과제, 본인 과제에 대한 피드백 알림을 받습니다.
따라서 다른 팀원이 과제를 등록한 것과 팀장이 다른 팀원의 과제에 피드백한 알림은 받지 않습니다.

## Tasks

- 카테고리에 따른 알림 전송 대상 제어
- 활동 관련 알림에 "새 게시글"을 카테고리명으로 변경

## ETC
해당 작업에서 활동 그룹에 참여 승인된 즉, 실제 활동 멤버를 List 값으로 받기 위해 아래와 같은 메소드를 작성했습니다. 아마 다른 수정사항들 작업하실 때 필요할 것 같습니다. 참고해주세요!
`List<GroupMember> findAllByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status);`


## Screenshot
현재 202211522, 202211523 학생이 팀원으로 참여하고 있는 활동입니다. 팀장의 주차별활동, 과제는 두 사람 모두 받지만 202211523 학생의 제출알림은 팀장에게만, 팀장이 202211523 학생에게 피드백을 단 것은 202211523 학생만 알림을 받을 수 있습니다.

<img width="854" alt="image" src="https://github.com/user-attachments/assets/00dd3256-8fd9-4d84-8f02-6e9383f6924f">


