### PR TITLE
refactor: QA 피드백에 따른 활동 게시판 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupBoardController.java
@@ -22,7 +22,6 @@ import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoar
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardChildResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardReferenceDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardResponseDto;
-import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardUpdateResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.AssignmentSubmissionWithFeedbackResponseDto;
 import page.clab.api.global.common.dto.ApiResponse;
 import page.clab.api.global.common.dto.PagedResponseDto;
@@ -80,7 +79,7 @@ public class ActivityGroupBoardController {
     @GetMapping("")
     public ApiResponse<ActivityGroupBoardResponseDto> getActivityGroupBoardById(
             @RequestParam(name = "activityGroupBoardId") Long activityGroupBoardId
-    ) {
+    ) throws PermissionDeniedException {
         ActivityGroupBoardResponseDto board = activityGroupBoardService.getActivityGroupBoardById(activityGroupBoardId);
         return ApiResponse.success(board);
     }
@@ -96,7 +95,7 @@ public class ActivityGroupBoardController {
             @RequestParam(name = "size", defaultValue = "20") int size,
             @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
             @RequestParam(name = "sortDirection", defaultValue = "desc") List<String> sortDirection
-    ) throws SortingArgumentException, InvalidColumnException {
+    ) throws SortingArgumentException, InvalidColumnException, PermissionDeniedException {
         Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupBoardResponseDto.class);
         PagedResponseDto<ActivityGroupBoardResponseDto> boards = activityGroupBoardService.getActivityGroupBoardByCategory(activityGroupId, category, pageable);
         return ApiResponse.success(boards);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -19,15 +19,13 @@ import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoar
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardChildResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardReferenceDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardResponseDto;
-import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupBoardUpdateResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.AssignmentSubmissionWithFeedbackResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.FeedbackResponseDto;
-import page.clab.api.domain.activity.activitygroup.exception.AssignmentBoardHasNoDueDateTimeException;
-import page.clab.api.domain.activity.activitygroup.exception.FeedbackBoardHasNoContentException;
+import page.clab.api.domain.activity.activitygroup.exception.AlreadySubmittedThisWeekAssignmentException;
 import page.clab.api.domain.activity.activitygroup.exception.InvalidParentBoardException;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
-import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
 import page.clab.api.domain.memberManagement.member.domain.Member;
+import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.external.memberManagement.notification.application.port.ExternalSendNotificationUseCase;
 import page.clab.api.global.common.dto.PagedResponseDto;
@@ -59,7 +57,11 @@ public class ActivityGroupBoardService {
             throw new PermissionDeniedException("활동 그룹 멤버만 게시글을 등록할 수 있습니다.");
         }
 
+        validateCanCreateBoard(activityGroup, requestDto.getCategory(), currentMember);
+
         validateParentBoard(requestDto.getCategory(), parentId);
+
+        validateAlreadySubmittedAssignmentThisWeek(requestDto.getCategory(), parentId, currentMember.getId());
 
         List<UploadedFile> uploadedFiles = uploadedFileService.getUploadedFilesByUrls(requestDto.getFileUrls());
 
@@ -77,6 +79,50 @@ public class ActivityGroupBoardService {
         return ActivityGroupBoardReferenceDto.toDto(board.getId(), activityGroupId, parentId);
     }
 
+    private void validateCanCreateBoard(ActivityGroup activityGroup, ActivityGroupBoardCategory category, Member currentMember) throws PermissionDeniedException {
+        Role role = currentMember.getRole();
+        boolean isRequireAdminOrLeaderCategory = category == ActivityGroupBoardCategory.NOTICE ||
+                                                 category == ActivityGroupBoardCategory.WEEKLY_ACTIVITY ||
+                                                 category == ActivityGroupBoardCategory.ASSIGNMENT ||
+                                                 category == ActivityGroupBoardCategory.FEEDBACK;
+
+        //NOTICE, WEEKLY_ACTIVITY, ASSIGNMENT, FEEDBACK 카테고리에서 권한이 ADMIN 이상이 아니거나, 리더가 아니면 예외처리
+        if (isRequireAdminOrLeaderCategory && !(role.isHigherThanOrEqual(Role.ADMIN) || activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember))) {
+            throw new PermissionDeniedException("해당 카테고리에서 게시글을 작성할 권한이 없습니다.");
+        }
+    }
+
+    private boolean hasAccessToBoard(ActivityGroup activityGroup, ActivityGroupBoard board, Member currentMember) {
+        //카테고리가 SUBMIT이거나, FEEDBACK일 시, 제출자 또는 리더만이 해당 게시물에 접근 가능
+        if (board.getCategory() == ActivityGroupBoardCategory.SUBMIT || board.getCategory() == ActivityGroupBoardCategory.FEEDBACK) {
+            return isSubmitterOrLeader(activityGroup, board, currentMember);
+        }
+        return true;
+    }
+
+    private boolean isSubmitterOrLeader(ActivityGroup activityGroup, ActivityGroupBoard board, Member currentMember) {
+        boolean isSubmitter = board.getMemberId().equals(currentMember.getId());
+        boolean isLeader = activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember);
+        //FEEDBACK을 가져오기 위해, parent의 카테고리가 SUBMIT이고, 현재 로그인한 멤버인지 확인
+        if (board.getCategory() == ActivityGroupBoardCategory.FEEDBACK) {
+            ActivityGroupBoard parentBoard = board.getParent();
+            boolean isParentSubmitter = parentBoard != null
+                    && parentBoard.getCategory() == ActivityGroupBoardCategory.SUBMIT
+                    && parentBoard.getMemberId().equals(currentMember.getId());
+            return isLeader || isParentSubmitter;
+        }
+        return isSubmitter || isLeader;
+    }
+
+    private void validateAlreadySubmittedAssignmentThisWeek(ActivityGroupBoardCategory category, Long parentId, String memberId) {
+        if(category == ActivityGroupBoardCategory.SUBMIT) {
+            boolean hasSubmitted = activityGroupBoardRepository.existsByParentIdAndCategoryAndMemberId(parentId, ActivityGroupBoardCategory.SUBMIT, memberId);
+            if(hasSubmitted) {
+                throw new AlreadySubmittedThisWeekAssignmentException();
+            }
+        }
+    }
+
     @Transactional(readOnly = true)
     public PagedResponseDto<ActivityGroupBoardResponseDto> getAllActivityGroupBoard(Pageable pageable) {
         Page<ActivityGroupBoard> boards = activityGroupBoardRepository.findAll(pageable);
@@ -87,19 +133,35 @@ public class ActivityGroupBoardService {
     }
 
     @Transactional(readOnly = true)
-    public ActivityGroupBoardResponseDto getActivityGroupBoardById(Long activityGroupBoardId) {
+    public ActivityGroupBoardResponseDto getActivityGroupBoardById(Long activityGroupBoardId) throws PermissionDeniedException {
+        Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroupBoard board = getActivityGroupBoardByIdOrThrow(activityGroupBoardId);
+        if(!activityGroupMemberService.isGroupMember(board.getActivityGroup(), currentMember.getId())) {
+            throw new PermissionDeniedException("해당 활동 그룹의 멤버가 아닙니다.");
+        }
+        if(!hasAccessToBoard(board.getActivityGroup(), board, currentMember)) {
+            throw new PermissionDeniedException("해당 게시물을 조회할 권한이 없습니다.");
+        }
         MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getMemberBasicInfoById(board.getMemberId());
         return ActivityGroupBoardResponseDto.toDto(board, memberBasicInfoDto);
     }
 
     @Transactional(readOnly = true)
-    public PagedResponseDto<ActivityGroupBoardResponseDto> getActivityGroupBoardByCategory(Long activityGroupId, ActivityGroupBoardCategory category, Pageable pageable) {
+    public PagedResponseDto<ActivityGroupBoardResponseDto> getActivityGroupBoardByCategory(Long activityGroupId, ActivityGroupBoardCategory category, Pageable pageable) throws PermissionDeniedException {
+        Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
+        ActivityGroup activityGroup = activityGroupAdminService.getActivityGroupByIdOrThrow(activityGroupId);
+        if (!activityGroupMemberService.isGroupMember(activityGroup, currentMember.getId())) {
+            throw new PermissionDeniedException("해당 활동 그룹의 멤버가 아닙니다.");
+        }
         Page<ActivityGroupBoard> boards = activityGroupBoardRepository.findAllByActivityGroup_IdAndCategory(activityGroupId, category, pageable);
-        return new PagedResponseDto<>(boards.map(board -> {
-            MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getMemberBasicInfoById(board.getMemberId());
-            return ActivityGroupBoardResponseDto.toDto(board, memberBasicInfoDto);
-        }));
+        List<ActivityGroupBoardResponseDto> filteredBoards = boards.stream()
+                .filter(board -> hasAccessToBoard(board.getActivityGroup(), board, currentMember))
+                .map(board -> {
+                    MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getMemberBasicInfoById(board.getMemberId());
+                    return ActivityGroupBoardResponseDto.toDto(board, memberBasicInfoDto);
+                })
+                .toList();
+        return new PagedResponseDto<>(new PageImpl<>(filteredBoards, pageable, boards.getTotalElements()));
     }
 
     @Transactional(readOnly = true)
@@ -107,19 +169,26 @@ public class ActivityGroupBoardService {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroupBoard parentBoard = getActivityGroupBoardByIdOrThrow(parentId);
         Long activityGroupId = parentBoard.getActivityGroup().getId();
+        if (!activityGroupMemberService.isGroupMember(parentBoard.getActivityGroup(), currentMember.getId())) {
+            throw new PermissionDeniedException("해당 활동 그룹의 멤버가 아닙니다.");
+        }
 
         GroupMember groupLeader = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
         parentBoard.validateAccessPermission(currentMember, groupLeader);
 
         List<ActivityGroupBoard> childBoards = getChildBoards(parentId);
-        Page<ActivityGroupBoard> boards = new PageImpl<>(childBoards, pageable, childBoards.size());
-        return new PagedResponseDto<>(boards.map(this::toActivityGroupBoardChildResponseDtoWithMemberInfo));
+        List<ActivityGroupBoardChildResponseDto> filteredBoards = childBoards.stream()
+                .filter(board -> hasAccessToBoard(board.getActivityGroup(), board, currentMember))
+                .map(this::toActivityGroupBoardChildResponseDtoWithMemberInfo)
+                .toList();
+
+        return new PagedResponseDto<>(new PageImpl<>(filteredBoards, pageable, filteredBoards.size()));
     }
 
     @Transactional(readOnly = true)
     public List<AssignmentSubmissionWithFeedbackResponseDto> getMyAssignmentsWithFeedbacks(Long parentId) {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
-        ActivityGroupBoard parentBoard = getActivityGroupBoardByIdOrThrow(parentId);
+
         List<ActivityGroupBoard> mySubmissions = activityGroupBoardRepository.findMySubmissionsWithFeedbacks(parentId, currentMember.getId());
         return mySubmissions.stream()
                 .map(submission -> {
@@ -172,15 +241,16 @@ public class ActivityGroupBoardService {
     }
 
     private List<ActivityGroupBoard> getChildBoards(Long activityGroupBoardId) {
-        ActivityGroupBoard board = getActivityGroupBoardByIdOrThrow(activityGroupBoardId);
         List<ActivityGroupBoard> children = activityGroupBoardRepository.findAllChildrenByParentId(activityGroupBoardId);
         children.sort(Comparator.comparing(ActivityGroupBoard::getCreatedAt).reversed());
         return children;
     }
 
     public ActivityGroupBoardChildResponseDto toActivityGroupBoardChildResponseDtoWithMemberInfo(ActivityGroupBoard activityGroupBoard) {
+        Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         MemberBasicInfoDto memberBasicInfo = externalRetrieveMemberUseCase.getMemberBasicInfoById(activityGroupBoard.getMemberId());
         List<ActivityGroupBoardChildResponseDto> childrenDtos = activityGroupBoard.getChildren().stream()
+                .filter(children -> hasAccessToBoard(children.getActivityGroup(), children, currentMember))
                 .map(this::toActivityGroupBoardChildResponseDtoWithMemberInfo)
                 .toList();
         return ActivityGroupBoardChildResponseDto.toDto(activityGroupBoard, memberBasicInfo, childrenDtos);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -84,14 +84,14 @@ public class ActivityGroupBoardService {
                                                  category == ActivityGroupBoardCategory.ASSIGNMENT ||
                                                  category == ActivityGroupBoardCategory.FEEDBACK;
 
-        //NOTICE, WEEKLY_ACTIVITY, ASSIGNMENT, FEEDBACK 카테고리에서 권한이 ADMIN 이상이 아니거나, 리더가 아니면 예외처리
+        // NOTICE, WEEKLY_ACTIVITY, ASSIGNMENT, FEEDBACK 카테고리에서 권한이 ADMIN 이상이 아니거나, 리더가 아니면 예외처리
         if (isRequireAdminOrLeaderCategory && !(role.isHigherThanOrEqual(Role.ADMIN) || activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember))) {
             throw new PermissionDeniedException("해당 카테고리에서 게시글을 작성할 권한이 없습니다.");
         }
     }
 
     private boolean hasAccessToBoard(ActivityGroup activityGroup, ActivityGroupBoard board, Member currentMember) {
-        //카테고리가 SUBMIT이거나, FEEDBACK일 시, 제출자 또는 리더만이 해당 게시물에 접근 가능
+        // 카테고리가 SUBMIT이거나, FEEDBACK일 시, 제출자 또는 리더만이 해당 게시물에 접근 가능
         if (board.getCategory() == ActivityGroupBoardCategory.SUBMIT || board.getCategory() == ActivityGroupBoardCategory.FEEDBACK) {
             return isSubmitterOrLeader(activityGroup, board, currentMember);
         }
@@ -101,7 +101,7 @@ public class ActivityGroupBoardService {
     private boolean isSubmitterOrLeader(ActivityGroup activityGroup, ActivityGroupBoard board, Member currentMember) {
         boolean isSubmitter = board.getMemberId().equals(currentMember.getId());
         boolean isLeader = activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember);
-        //FEEDBACK을 가져오기 위해, parent의 카테고리가 SUBMIT이고, 현재 로그인한 멤버인지 확인
+        // FEEDBACK을 가져오기 위해, parent의 카테고리가 SUBMIT이고, 현재 로그인한 멤버인지 확인
         if (board.getCategory() == ActivityGroupBoardCategory.FEEDBACK) {
             ActivityGroupBoard parentBoard = board.getParent();
             boolean isParentSubmitter = parentBoard != null

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -58,9 +58,7 @@ public class ActivityGroupBoardService {
         }
 
         validateCanCreateBoard(activityGroup, requestDto.getCategory(), currentMember);
-
         validateParentBoard(requestDto.getCategory(), parentId);
-
         validateAlreadySubmittedAssignmentThisWeek(requestDto.getCategory(), parentId, currentMember.getId());
 
         List<UploadedFile> uploadedFiles = uploadedFileService.getUploadedFilesByUrls(requestDto.getFileUrls());

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -113,9 +113,9 @@ public class ActivityGroupBoardService {
     }
 
     private void validateAlreadySubmittedAssignmentThisWeek(ActivityGroupBoardCategory category, Long parentId, String memberId) {
-        if(category.isSubmit()) {
+        if (category.isSubmit()) {
             boolean hasSubmitted = activityGroupBoardRepository.existsByParentIdAndCategoryAndMemberId(parentId, ActivityGroupBoardCategory.SUBMIT, memberId);
-            if(hasSubmitted) {
+            if (hasSubmitted) {
                 throw new AlreadySubmittedThisWeekAssignmentException();
             }
         }
@@ -134,10 +134,10 @@ public class ActivityGroupBoardService {
     public ActivityGroupBoardResponseDto getActivityGroupBoardById(Long activityGroupBoardId) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroupBoard board = getActivityGroupBoardByIdOrThrow(activityGroupBoardId);
-        if(!activityGroupMemberService.isGroupMember(board.getActivityGroup(), currentMember.getId())) {
+        if (!activityGroupMemberService.isGroupMember(board.getActivityGroup(), currentMember.getId())) {
             throw new PermissionDeniedException("해당 활동 그룹의 멤버가 아닙니다.");
         }
-        if(!hasAccessToBoard(board.getActivityGroup(), board, currentMember)) {
+        if (!hasAccessToBoard(board.getActivityGroup(), board, currentMember)) {
             throw new PermissionDeniedException("해당 게시물을 조회할 권한이 없습니다.");
         }
         MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getMemberBasicInfoById(board.getMemberId());

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -106,7 +106,7 @@ public class ActivityGroupBoardService {
             ActivityGroupBoard parentBoard = board.getParent();
             boolean isParentSubmitter = parentBoard != null
                     && parentBoard.getCategory().isSubmit()
-                    && parentBoard.getMemberId().equals(currentMember.getId());
+                    && parentBoard.isOwner(currentMember.getId());
             return isLeader || isParentSubmitter;
         }
         return isSubmitter || isLeader;

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -29,7 +29,6 @@ import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupRes
 import page.clab.api.domain.activity.activitygroup.dto.response.ActivityGroupStatusResponseDto;
 import page.clab.api.domain.activity.activitygroup.dto.response.GroupMemberResponseDto;
 import page.clab.api.domain.activity.activitygroup.exception.AlreadyAppliedException;
-import page.clab.api.domain.activity.activitygroup.exception.InvalidCategoryException;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
 import page.clab.api.domain.memberManagement.member.domain.Member;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
@@ -73,7 +72,7 @@ public class ActivityGroupMemberService {
         List<ActivityGroupBoardResponseDto> activityGroupBoardResponseDtos =
                 details.getActivityGroupBoards().stream()
                         .map(board -> {
-                            MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getCurrentMemberBasicInfo();
+                            MemberBasicInfoDto memberBasicInfoDto = externalRetrieveMemberUseCase.getMemberBasicInfoById(board.getMemberId());
                             return ActivityGroupBoardResponseDto.toDto(board, memberBasicInfoDto);
                         })
                         .toList();
@@ -198,7 +197,7 @@ public class ActivityGroupMemberService {
     }
 
     public boolean isGroupMember(ActivityGroup activityGroup, String memberId) {
-        return groupMemberRepository.existsByActivityGroupAndMemberId(activityGroup, memberId);
+        return groupMemberRepository.existsByActivityGroupAndMemberIdAndStatus(activityGroup, memberId, GroupMemberStatus.ACCEPTED);
     }
 
     public GroupMember save(GroupMember groupMember) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupBoardRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupBoardRepository.java
@@ -20,6 +20,8 @@ public interface ActivityGroupBoardRepository extends JpaRepository<ActivityGrou
 
     List<ActivityGroupBoard> findAllChildrenByParentId(Long activityGroupBoardId);
 
+    boolean existsByParentIdAndCategoryAndMemberId(Long parentId, ActivityGroupBoardCategory category, String memberId);
+
     @Query(value = "SELECT a.* FROM activity_group_board a WHERE a.is_deleted = true", nativeQuery = true)
     Page<ActivityGroupBoard> findAllByIsDeletedTrue(Pageable pageable);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
@@ -31,5 +31,5 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
 
     Page<GroupMember> findAllByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status, org.springframework.data.domain.Pageable pageable);
 
-    boolean existsByActivityGroupAndMemberId(ActivityGroup activityGroup, String memberId);
+    boolean existsByActivityGroupAndMemberIdAndStatus(ActivityGroup activityGroup, String memberId, GroupMemberStatus status);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroupBoardCategory.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroupBoardCategory.java
@@ -15,4 +15,24 @@ public enum ActivityGroupBoardCategory {
 
     private final String key;
     private final String description;
+
+    public boolean isNotice() {
+        return this == NOTICE;
+    }
+
+    public boolean isWeeklyActivity() {
+        return this == WEEKLY_ACTIVITY;
+    }
+
+    public boolean isFeedback() {
+        return this == FEEDBACK;
+    }
+
+    public boolean isAssignment() {
+        return this == ASSIGNMENT;
+    }
+
+    public boolean isSubmit() {
+        return this == SUBMIT;
+    }
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/exception/AlreadySubmittedThisWeekAssignmentException.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/exception/AlreadySubmittedThisWeekAssignmentException.java
@@ -1,0 +1,14 @@
+package page.clab.api.domain.activity.activitygroup.exception;
+
+public class AlreadySubmittedThisWeekAssignmentException extends RuntimeException{
+
+    private static final String DEFAULT_MESSAGE = "해당 주차의 과제물이 이미 제출되었습니다.";
+
+    public AlreadySubmittedThisWeekAssignmentException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public AlreadySubmittedThisWeekAssignmentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import page.clab.api.domain.activity.activitygroup.exception.ActivityGroupNotFinishedException;
 import page.clab.api.domain.activity.activitygroup.exception.ActivityGroupNotProgressingException;
 import page.clab.api.domain.activity.activitygroup.exception.AlreadyAppliedException;
+import page.clab.api.domain.activity.activitygroup.exception.AlreadySubmittedThisWeekAssignmentException;
 import page.clab.api.domain.activity.activitygroup.exception.AssignmentBoardHasNoDueDateTimeException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAbsentExcuseException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAttendanceException;
@@ -174,6 +175,7 @@ public class GlobalExceptionHandler {
             CloudStorageNotEnoughException.class,
             ActivityGroupNotFinishedException.class,
             ActivityGroupNotProgressingException.class,
+            AlreadySubmittedThisWeekAssignmentException.class,
             LeaderStatusChangeNotAllowedException.class,
             AlreadyAppliedException.class,
             DuplicateReportException.class,


### PR DESCRIPTION
## Summary

> #500 

1. 과제 제출을 한 사람이 여러 번 할 수 있는 문제로 인해, 과제 제출을 1회만 가능하도록 validation을 추가했습니다.
2. 게시물의 카테고리별 권한 제어 로직을 작성했습니다.
- 게시물 생성
  - 카테고리가 `NOTICE`, `WEEKLY_ACTIVITY`,  `ASSIGNMENT`, `FEEDBACK`인 경우에, 권한이 ADMIN 이상이거나, 그룹의 리더만 게시물을 작성할 수 있도록 작성했습니다.

- 게시물 조회
  - 카테고리가 SUBMIT이거나 FEEDBACK일 시, 과제 제출자 혹은 그룹의 리더만이 해당 게시물에 접근 가능하도록 작성했습니다.


## Tasks

- 과제 제출을 1회만 가능하도록 validation 추가
- 과제 수정 시 updatedAt 정보가 수정되는지 확인
- 게시글 카테고리별 생성 권한 제어
- 게시글 카테고리별 조회 권한 제어


## ETC

![스크린샷 2024-08-24 032145](https://github.com/user-attachments/assets/90afaa68-36d1-46a2-a9f7-9e67c2f7a06b)
과제 수정 시, updatedAt 정보가 정상적으로 수정됨을 확인했습니다.

## Screenshot

### 과제 제출 1회만 가능하도록 validation 추가
```
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 3,
    "take": 3,
    "items": [
      {
        "id": 4,
        "memberId": "202014941",
        "memberName": "송재훈",
        "parentId": 3,
        "category": "SUBMIT",
        "title": "202014941 1주차 과제 제출",
        "content": "1주차 과제 제출하도록 하겠습니다.",
        "files": [],
        "dueDateTime": "2024-08-29T17:17:56.951",
        "createdAt": "2024-08-24T03:02:06.071873",
        "updatedAt": "2024-08-24T03:02:06.071873"
      },
      {
        "id": 3,
        "memberId": "leader",
        "memberName": "리더",
        "parentId": 2,
        "category": "ASSIGNMENT",
        "title": "1주차 과제",
        "content": "1주차 과제입니다. 제출해주세요.",
        "files": [],
        "dueDateTime": "2024-08-29T17:17:56.951",
        "createdAt": "2024-08-24T02:58:37.567156",
        "updatedAt": "2024-08-24T02:58:37.567156"
      },
      {
        "id": 2,
        "memberId": "leader",
        "memberName": "리더",
        "parentId": null,
        "category": "WEEKLY_ACTIVITY",
        "title": "1주차 활동",
        "content": "1주차입니다.",
        "files": [],
        "dueDateTime": "2024-08-30T17:17:56.951",
        "createdAt": "2024-08-24T02:56:42.017053",
        "updatedAt": "2024-08-24T02:56:42.017053"
      }
    ]
  }
}
```
위 상태에서, 해당 주차에서 한번 더 과제 제출 진행
- 결과
![스크린샷 2024-08-24 031838](https://github.com/user-attachments/assets/3461fa6d-e44b-433f-87b3-5d2fb92da113)

### 게시글 카테고리별 생성 권한 제어
- Accepted되지 않은 멤버가 게시물을 생성하려고 한 결과
![스크린샷 2024-08-24 035155](https://github.com/user-attachments/assets/1b71fd6f-b263-4d09-9b06-b361a9a7f386)

### 게시글 카테고리별 조회 권한 제어
- 활동 멤버가 아닌 인원이 활동 그룹 게시판 단일 조회
![스크린샷 2024-08-24 213001](https://github.com/user-attachments/assets/ed58cada-aeb9-46ab-a389-d83fbf17fba2)
활동 그룹 게시판 조회, 나의 제출 과제 및 피드백 조회를 제외하고는 전부 같은 403 Error가 발생합니다.


![스크린샷 2024-08-24 222322](https://github.com/user-attachments/assets/953cfd57-aa32-4f76-b3a5-a56378df8fb7)
위와 같이 제출된 과제가 두 개 있는 상태이고, 201912000이 로그인한 상태에서,
- 활동 그룹 id에 대한 카테고리별 게시판 조회
![스크린샷 2024-08-24 222442](https://github.com/user-attachments/assets/1b09c0c6-1e23-4054-bc8b-75d78c37b57f)

- 활동 그룹 게시판 계층 구조적 조회
![스크린샷 2024-08-25 011012](https://github.com/user-attachments/assets/7a147189-1c84-46bf-8910-ab21470827df)

- 활동 그룹 게시판 단일 조회
  - 본인의 과제가 아닌 다른 사람의 과제를 조회했을 때
![스크린샷 2024-08-24 231825](https://github.com/user-attachments/assets/71bd5d6d-9480-4906-9fbf-4845aa795429)
  - 본인 과제를 조회했을 때
![스크린샷 2024-08-24 231924](https://github.com/user-attachments/assets/2c0d4e30-0fc6-42f4-a342-01a5665fa4cb)

- 나의 제출 과제 및 피드백 조회(201912000으로 로그인)
![image](https://github.com/user-attachments/assets/98ea6556-fbc7-4f0a-9925-789c45e06db7)



*이 외에, Leader로 로그인 후 모든 api를 조회해봤을 때, 일부가 아닌 모든 데이터가 정상적으로 나오는 것을 확인했습니다.*

