### PR TITLE
refactor: 엔드포인트 URI 로깅에 요청 파라미터 추가 완료

### DIFF
--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -65,11 +65,6 @@ public class SlackServiceHelper {
         this.attributeStrategy = attributeStrategy;
     }
 
-    private static String getUsername() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
-    }
-
     public CompletableFuture<Boolean> sendSlackMessage(String webhookUrl, AlertType alertType, HttpServletRequest request, Object additionalData) {
         List<LayoutBlock> blocks = createBlocks(alertType, request, additionalData);
         return CompletableFuture.supplyAsync(() -> {
@@ -152,7 +147,7 @@ public class SlackServiceHelper {
         String requestUrl = request.getRequestURI();
         String queryString = request.getQueryString();
         String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
-        String username = getUsername();
+        String username = getUsername(request);
 
         String errorMessage = e.getMessage() == null ? "No error message provided" : e.getMessage();
         String detailedMessage = extractMessageAfterException(errorMessage);

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackServiceHelper.java
@@ -150,6 +150,8 @@ public class SlackServiceHelper {
     private List<LayoutBlock> createErrorBlocks(HttpServletRequest request, Exception e) {
         String httpMethod = request.getMethod();
         String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
         String username = getUsername();
 
         String errorMessage = e.getMessage() == null ? "No error message provided" : e.getMessage();
@@ -159,7 +161,7 @@ public class SlackServiceHelper {
                 section(section -> section.text(markdownText(":firecracker: *Server Error*"))),
                 section(section -> section.fields(Arrays.asList(
                         markdownText("*User:*\n" + username),
-                        markdownText("*Endpoint:*\n[" + httpMethod + "] " + requestUrl)
+                        markdownText("*Endpoint:*\n[" + httpMethod + "] " + fullUrl)
                 ))),
                 section(section -> section.text(markdownText("*Error Message:*\n" + detailedMessage))),
                 section(section -> section.text(markdownText("*Stack Trace:*\n```" + getStackTraceSummary(e) + "```")))
@@ -169,6 +171,8 @@ public class SlackServiceHelper {
     private List<LayoutBlock> createSecurityAlertBlocks(HttpServletRequest request, AlertType alertType, String additionalMessage) {
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
         String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
         String username = getUsername(request);
         String location = getLocation(request);
 
@@ -178,7 +182,7 @@ public class SlackServiceHelper {
                         markdownText("*User:*\n" + username),
                         markdownText("*IP Address:*\n" + clientIpAddress),
                         markdownText("*Location:*\n" + location),
-                        markdownText("*Endpoint:*\n" + requestUrl)
+                        markdownText("*Endpoint:*\n" + fullUrl)
                 ))),
                 section(section -> section.text(markdownText("*Details:*\n" + alertType.getDefaultMessage() + "\n" + additionalMessage)))
         );

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -146,9 +146,14 @@ public class SecurityConfig {
     private void apiLogging(HttpServletRequest request, HttpServletResponse response, String clientIpAddress, String message) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+
         String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
         String httpMethod = request.getMethod();
         int httpStatus = response.getStatus();
-        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, message);
+        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, message);
     }
+
 }

--- a/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
+++ b/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
@@ -2,9 +2,9 @@ package page.clab.api.global.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import page.clab.api.global.util.ApiLogger;

--- a/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
+++ b/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
@@ -25,7 +25,11 @@ public class ApiLoggingInterceptor implements HandlerInterceptor {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+
         String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
         String httpMethod = request.getMethod();
         int httpStatus = response.getStatus();
 
@@ -34,9 +38,9 @@ public class ApiLoggingInterceptor implements HandlerInterceptor {
         long duration = endTime - startTime;
 
         if (ex == null) {
-            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration);
+            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration);
         } else {
-            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration, ex.getMessage());
+            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration, ex.getMessage());
         }
     }
 }

--- a/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
+++ b/src/main/java/page/clab/api/global/handler/ApiLoggingInterceptor.java
@@ -2,17 +2,19 @@ package page.clab.api.global.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import page.clab.api.global.util.HttpReqResUtil;
+import page.clab.api.global.util.ApiLogger;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class ApiLoggingInterceptor implements HandlerInterceptor {
+
+    private final ApiLogger apiLogger;
 
     @Override
     public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws Exception {
@@ -22,25 +24,6 @@ public class ApiLoggingInterceptor implements HandlerInterceptor {
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, @NotNull Object handler, Exception ex) throws Exception {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
-        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-
-        String requestUrl = request.getRequestURI();
-        String queryString = request.getQueryString();
-        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
-
-        String httpMethod = request.getMethod();
-        int httpStatus = response.getStatus();
-
-        long startTime = (Long) request.getAttribute("startTime");
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-
-        if (ex == null) {
-            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration);
-        } else {
-            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration, ex.getMessage());
-        }
+        apiLogger.logRequestDuration(request, response, ex);
     }
 }

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -132,6 +133,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
+            AuthenticationException.class,
             AuthenticationInfoNotFoundException.class,
             UnAuthorizeException.class,
             LoginFailedException.class,

--- a/src/main/java/page/clab/api/global/util/ApiLogger.java
+++ b/src/main/java/page/clab/api/global/util/ApiLogger.java
@@ -1,0 +1,50 @@
+package page.clab.api.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ApiLogger {
+
+    public void logRequest(HttpServletRequest request, HttpServletResponse response, String clientIpAddress, String message) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+
+        String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
+        String httpMethod = request.getMethod();
+        int httpStatus = response.getStatus();
+
+        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, message);
+    }
+
+    public void logRequestDuration(HttpServletRequest request, HttpServletResponse response, Exception ex) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+
+        String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
+        String httpMethod = request.getMethod();
+        int httpStatus = response.getStatus();
+
+        long startTime = (Long) request.getAttribute("startTime");
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        if (ex == null) {
+            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration);
+        } else {
+            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration, ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

> #509 

현재 엔드포인트에 대한 로깅이 URI까지만 출력되고 있으며, 사용자가 요청한 파라미터는 로그에 포함되지 않고 있습니다. 이로 인해 특히 버그가 발생했을 때 문제를 추적하는 데 어려움이 있습니다. URI에 사용자가 요청한 파라미터를 포함시켜 로그로 출력하여 문제를 더 효과적으로 추적할 수 있도록 개선이 필요합니다.

### Tasks

- 요청 파라미터를 URI에 덧붙여 로그에 출력되도록 수정
- HttpServletRequest에서 요청 파라미터를 추출하여 URI와 함께 로그로 출력
- 예외 발생 시에도 요청 파라미터가 포함된 로그가 출력되도록 로직 추가
- 로깅 형식을 기존 로그와 일관되도록 조정

### Screenshot

![로그](https://github.com/user-attachments/assets/817873ba-3f55-4668-85da-14e292743b1f)