### PR TITLE
refactor: 활동 그룹 리더가 여러 명이 될 수 있음에 따른 코드 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import page.clab.api.domain.activity.activitygroup.dao.ActivityGroupBoardRepository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupBoard;
@@ -168,8 +169,8 @@ public class ActivityGroupBoardService {
         Long activityGroupId = parentBoard.getActivityGroup().getId();
         validateGroupMember(parentBoard.getActivityGroup(), currentMember);
 
-        GroupMember groupLeader = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
-        parentBoard.validateAccessPermission(currentMember, groupLeader);
+        List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
+        parentBoard.validateAccessPermission(currentMember, groupLeaders);
 
         List<ActivityGroupBoard> childBoards = getChildBoards(parentId);
         List<ActivityGroupBoardChildResponseDto> filteredBoards = childBoards.stream()
@@ -312,9 +313,9 @@ public class ActivityGroupBoardService {
                 externalSendNotificationUseCase.sendNotificationToMembers(groupMembersId, "[" + activityGroup.getName() + "] " + member.getName() + "님이 새 " + board.getCategory().getDescription() + "을(를) 등록하였습니다.");
             }
         } else {
-            GroupMember groupLeader = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
-            if (groupLeader != null) {
-                externalSendNotificationUseCase.sendNotificationToMember(groupLeader.getMemberId(), "[" + activityGroup.getName() + "] " + member.getName() + "님이 새 " + board.getCategory().getDescription() + "을(를) 등록하였습니다.");
+            List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
+            if (!CollectionUtils.isEmpty(groupLeaders)) {
+                groupLeaders.forEach(leader -> externalSendNotificationUseCase.sendNotificationToMember(leader.getMemberId(), "[" + activityGroup.getName() + "] " + member.getName() + "님이 새 " + board.getCategory().getDescription() + "을(를) 등록하였습니다."));
             }
         }
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
@@ -21,7 +21,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
 
     boolean existsByMemberIdAndActivityGroupId(String memberId, Long activityGroupId);
 
-    Optional<GroupMember> findByActivityGroupIdAndRole(Long activityGroupId, ActivityGroupRole role);
+    List<GroupMember> findByActivityGroupIdAndRole(Long activityGroupId, ActivityGroupRole role);
 
     Optional<GroupMember> findByActivityGroupAndMemberId(ActivityGroup activityGroup, String memberId);
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroupBoard.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroupBoard.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoardRequestDto;
+import org.springframework.util.CollectionUtils;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupBoardUpdateRequestDto;
 import page.clab.api.domain.activity.activitygroup.exception.AssignmentBoardHasNoDueDateTimeException;
 import page.clab.api.domain.activity.activitygroup.exception.FeedbackBoardHasNoContentException;
@@ -111,8 +111,8 @@ public class ActivityGroupBoard extends BaseEntity {
         return this.category.equals(ActivityGroupBoardCategory.FEEDBACK);
     }
 
-    public void validateAccessPermission(Member member, GroupMember leader) throws PermissionDeniedException {
-        if (!member.isAdminRole() && leader != null && !leader.isOwner(member.getId())) {
+    public void validateAccessPermission(Member member, List<GroupMember> leaders) throws PermissionDeniedException {
+        if (!member.isAdminRole() && !CollectionUtils.isEmpty(leaders) && leaders.stream().noneMatch(leader -> leader.isOwner(member.getId()))) {
             if (this.isAssignment()) {
                 throw new PermissionDeniedException("과제 게시판에 접근할 권한이 없습니다.");
             }

--- a/src/main/java/page/clab/api/domain/activity/review/application/service/ReviewRegisterService.java
+++ b/src/main/java/page/clab/api/domain/activity/review/application/service/ReviewRegisterService.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.activity.review.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import page.clab.api.domain.activity.activitygroup.application.ActivityGroupMemberService;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupRole;
@@ -17,6 +18,8 @@ import page.clab.api.domain.activity.review.domain.Review;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.external.memberManagement.notification.application.port.ExternalSendNotificationUseCase;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -49,9 +52,9 @@ public class ReviewRegisterService implements RegisterReviewUseCase {
     }
 
     private void notifyGroupLeaderOfNewReview(ActivityGroup activityGroup, String memberName) {
-        GroupMember groupLeader = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroup.getId(), ActivityGroupRole.LEADER);
-        if (groupLeader != null) {
-            externalSendNotificationUseCase.sendNotificationToMember(groupLeader.getMemberId(), "[" + activityGroup.getName() + "] " + memberName + "님이 리뷰를 등록하였습니다.");
+        List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroup.getId(), ActivityGroupRole.LEADER);
+        if (!CollectionUtils.isEmpty(groupLeaders)) {
+            groupLeaders.forEach(leader -> externalSendNotificationUseCase.sendNotificationToMember(leader.getMemberId(), "[" + activityGroup.getName() + "] " + memberName + "님이 리뷰를 등록하였습니다."));
         }
     }
 

--- a/src/main/java/page/clab/api/domain/members/schedule/application/service/ScheduleRegisterService.java
+++ b/src/main/java/page/clab/api/domain/members/schedule/application/service/ScheduleRegisterService.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.members.schedule.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import page.clab.api.domain.activity.activitygroup.application.ActivityGroupAdminService;
 import page.clab.api.domain.activity.activitygroup.application.ActivityGroupMemberService;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
@@ -17,6 +18,7 @@ import page.clab.api.domain.members.schedule.domain.ScheduleType;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.exception.PermissionDeniedException;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -52,8 +54,8 @@ public class ScheduleRegisterService implements RegisterScheduleUseCase {
     }
 
     private void validateMemberIsGroupLeaderOrAdmin(MemberDetailedInfoDto memberInfo, ActivityGroup activityGroup) throws PermissionDeniedException {
-        GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroup.getId(), ActivityGroupRole.LEADER);
-        if (groupMember != null && !memberInfo.isAdminRole() && !groupMember.isOwner(memberInfo.getMemberId())) {
+        List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroup.getId(), ActivityGroupRole.LEADER);
+        if (!CollectionUtils.isEmpty(groupLeaders) && !memberInfo.isAdminRole() && groupLeaders.stream().noneMatch(leader -> leader.isOwner(memberInfo.getMemberId()))) {
             throw new PermissionDeniedException("해당 스터디 또는 프로젝트의 LEADER, 관리자만 그룹 일정을 추가할 수 있습니다.");
         }
     }


### PR DESCRIPTION
## Summary

> #510  

리더가 여러 명이 될 수 있지만, `GroupMemberRepository`의 `findByActivityGroupIdAndRole`에서는 단일 데이터를 리턴하고 있었습니다.
따라서, 해당 메서드의 반환 타입을 List로 변경하고, 그에 따른 변경점들을 수정했습니다.

## Tasks

- `findByActivityGroupIdAndRole` 반환 타입 List로 수정
- List 타입에 맞게 stream을 이용해 리더 판별

## ETC

해당 이슈로 인해 오류가 났었던 `활동 그룹 게시판 계층 구조적 조회`에서도 잘 작동하는 걸 확인할 수 있었습니다.
```
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 1,
    "take": 1,
    "items": [
      {
        "id": 9,
        "memberId": "leader",
        "memberName": "리더",
        "category": "ASSIGNMENT",
        "title": "1주차 과제 제출해주시기 바랍니다.",
        "content": "1주차 과제 제출해주세요!",
        "dueDateTime": "2024-08-30T15:02:20.623",
        "updatedAt": "2024-08-26T00:04:29.000072",
        "createdAt": "2024-08-26T00:04:29.000072",
        "files": [],
        "children": [
          {
            "id": 10,
            "memberId": "202014941",
            "memberName": "송재훈",
            "category": "SUBMIT",
            "title": "202014941 1주차 과제 제출입니다.",
            "content": "1주차 과제 내용입니다!",
            "dueDateTime": "2024-08-30T15:02:20.623",
            "updatedAt": "2024-08-26T00:05:29.107775",
            "createdAt": "2024-08-26T00:05:29.107775",
            "files": [],
            "children": [
              {
                "id": 13,
                "memberId": "leader",
                "memberName": "리더",
                "category": "FEEDBACK",
                "title": "202014941 피드백 내용입니다.",
                "content": "피드백 내용입니다",
                "dueDateTime": "2024-08-30T15:02:20.623",
                "updatedAt": "2024-08-26T00:08:05.409211",
                "createdAt": "2024-08-26T00:08:05.409211",
                "files": [],
                "children": []
              }
            ]
          }
        ]
      }
    ]
  }
}
```

## Screenshot


